### PR TITLE
業績管理システムの改修に対応

### DIFF
--- a/content/en/publications.md
+++ b/content/en/publications.md
@@ -114,14 +114,6 @@ projects: []
 1. Anthony Nguyen, Andréa Matsunaga, Kohei Ichikawa, Susumu Date, Maurício Tsugawa, Jason Haga, "Deployment of a Multi-Site Cloud Environment for Molecular Virtual Screenings", 11th IEEE International Conference on eScience2015, Aug. 2015.
 1. Yong Jin, Xin Yang, Raula Gaikovina Kula, Eunjong Choi, Katsuro Inoue, Hajimu Iida, "Quick Trigger on Stack Overflow: a Study of Gamification-Influenced Member Tendencies", Proc. 12th Working Conference on Mining Software Repositories (MSR), May. 2015.
 1. Patanamon Thongtanunam, Shane McIntosh, Ahmed E. Hassan, Hajimu Iida, "Investigating Code Review Practices in Defective Files: an Empirical Study of the Qt System", Proc. 12th Working Conference on Mining Software Repositories (MSR), May. 2015.
-1. Pongsakorn U-chupala, Kohei Ichikawa, Putchong Uthayopas, Susumu Date, Hirotake Abe, "Deployment and Evaluation of Bandwidth and Latency Aware Network Over Large-Scale Openflow Testbed", PRAGMA 28 Workshop, Apr. 2015.
-1. Xuliang Wang, Yasuhiro Watashiba, Kohei Ichikawa, "Flow-level monitoring based-on OpenFlow for categorizing network application", PRAGMA 28 Workshop, Apr. 2015.
-1. Chawanat Nakasan, Kohei Ichikawa, "Development of a Simple Multipath Openflow Controller for Multipath Tcp", PRAGMA 28 Workshop, Apr. 2015.
-1. Kar-Long Chan, Kohei Ichikawa, "A Hybrid Game Contents Streaming Method to Improve Graphic Quality Delivered by Cloud Gaming", Pragma 28 Workshop, Apr. 2015.
-1. Kazuki Hara, Yasuhiro Watashiba, Kohei Ichikawa, "Netspec: Software-Defined Network Behavior Test Tool", PRAGMA 28 Workshop, Apr. 2015.
-1. Arata Endo, Yasuhiro Watashiba, Yoshiyuki Kido, Susumu Date, Kiyoshi Kiyokawa, Haruo Takemura, "Improvement of Scalability in Sharing Application Screens between Tiled Display Walls", PRAGMA 28 Workshop, Apr. 2015.
-1. Yasuhiro Watashiba, Susumu Date, Hirotake Abe, Yoshiyuki Kido, Kohei Ichikawa, Hiroaki Yamanaka, Eiji Kawai, Shinji Shimojo, Haruo Takemura, "An Implementation of SDN-enhanced Job Management System with Bandwidth Control", PRAGMA 28 Workshop, Apr. 2015.
-1. Patanamon Thongtanunam, Chakkrit Tantithamthavorn, Raula Gaikovina Kula, Norihiro Yoshida, Hajimu Iida, Kenichi Matsumoto, " Who Should Review My Code? a File Location-Based Code-Reviewer Recommendation Approach for Modern Code Review", Proceedings of The 22nd IEEE International Conference on Software Analysis, Evolution, and Reengineering (SANER’15), Mar. 2015.
 
 ## Domestic Conference and Symposium
 
@@ -169,7 +161,6 @@ projects: []
 1. 上村 恭平, 藤原 賢二, 飯田 元, "Hardware Description Language を対象としたコードクローンの調査", 組込みシステム技術に関するサマーワークショップ　(SWTEST17), Aug. 2015.
 1. 上村 恭平, 藤原 賢二, 飯田 元, "Hardware Description Languageにおけるコードクローンのパターン分類", 電子情報通信学会技術報告, May. 2015.
 1. 金 勇, 藤原 賢二, 飯田 元, "Linuxディストリビューションにおけるパッチの適用過程の復元に向けて", 電子情報通信学会技術報告, May. 2015.
-1. 北口 善明, 西内 一馬, 市川 昊平, 近堂 徹, 柏崎 礼生, 中川 郁夫, 菊池 豊, "SDDE (Software Defined Disaster Emulation)プラットフォームを用いた経路冗長化環境に対する評価実験", 情報処理学会研究報告, Mar. 2015.
 
 ## Annual Domestic Meeting
 

--- a/content/ja/publications.md
+++ b/content/ja/publications.md
@@ -114,14 +114,6 @@ projects: []
 1. Anthony Nguyen, Andréa Matsunaga, Kohei Ichikawa, Susumu Date, Maurício Tsugawa, Jason Haga, "Deployment of a Multi-Site Cloud Environment for Molecular Virtual Screenings", 11th IEEE International Conference on eScience2015, Aug. 2015.
 1. Yong Jin, Xin Yang, Raula Gaikovina Kula, Eunjong Choi, Katsuro Inoue, Hajimu Iida, "Quick Trigger on Stack Overflow: a Study of Gamification-Influenced Member Tendencies", Proc. 12th Working Conference on Mining Software Repositories (MSR), May. 2015.
 1. Patanamon Thongtanunam, Shane McIntosh, Ahmed E. Hassan, Hajimu Iida, "Investigating Code Review Practices in Defective Files: an Empirical Study of the Qt System", Proc. 12th Working Conference on Mining Software Repositories (MSR), May. 2015.
-1. Pongsakorn U-chupala, Kohei Ichikawa, Putchong Uthayopas, Susumu Date, Hirotake Abe, "Deployment and Evaluation of Bandwidth and Latency Aware Network Over Large-Scale Openflow Testbed", PRAGMA 28 Workshop, Apr. 2015.
-1. Xuliang Wang, Yasuhiro Watashiba, Kohei Ichikawa, "Flow-level monitoring based-on OpenFlow for categorizing network application", PRAGMA 28 Workshop, Apr. 2015.
-1. Chawanat Nakasan, Kohei Ichikawa, "Development of a Simple Multipath Openflow Controller for Multipath Tcp", PRAGMA 28 Workshop, Apr. 2015.
-1. Kar-Long Chan, Kohei Ichikawa, "A Hybrid Game Contents Streaming Method to Improve Graphic Quality Delivered by Cloud Gaming", Pragma 28 Workshop, Apr. 2015.
-1. Kazuki Hara, Yasuhiro Watashiba, Kohei Ichikawa, "Netspec: Software-Defined Network Behavior Test Tool", PRAGMA 28 Workshop, Apr. 2015.
-1. Arata Endo, Yasuhiro Watashiba, Yoshiyuki Kido, Susumu Date, Kiyoshi Kiyokawa, Haruo Takemura, "Improvement of Scalability in Sharing Application Screens between Tiled Display Walls", PRAGMA 28 Workshop, Apr. 2015.
-1. Yasuhiro Watashiba, Susumu Date, Hirotake Abe, Yoshiyuki Kido, Kohei Ichikawa, Hiroaki Yamanaka, Eiji Kawai, Shinji Shimojo, Haruo Takemura, "An Implementation of SDN-enhanced Job Management System with Bandwidth Control", PRAGMA 28 Workshop, Apr. 2015.
-1. Patanamon Thongtanunam, Chakkrit Tantithamthavorn, Raula Gaikovina Kula, Norihiro Yoshida, Hajimu Iida, Kenichi Matsumoto, " Who Should Review My Code? a File Location-Based Code-Reviewer Recommendation Approach for Modern Code Review", Proceedings of The 22nd IEEE International Conference on Software Analysis, Evolution, and Reengineering (SANER’15), Mar. 2015.
 
 ## 国内学会研究会・シンポジウム等
 
@@ -169,7 +161,6 @@ projects: []
 1. 上村 恭平, 藤原 賢二, 飯田 元, "Hardware Description Language を対象としたコードクローンの調査", 組込みシステム技術に関するサマーワークショップ　(SWTEST17), Aug. 2015.
 1. 上村 恭平, 藤原 賢二, 飯田 元, "Hardware Description Languageにおけるコードクローンのパターン分類", 電子情報通信学会技術報告, May. 2015.
 1. 金 勇, 藤原 賢二, 飯田 元, "Linuxディストリビューションにおけるパッチの適用過程の復元に向けて", 電子情報通信学会技術報告, May. 2015.
-1. 北口 善明, 西内 一馬, 市川 昊平, 近堂 徹, 柏崎 礼生, 中川 郁夫, 菊池 豊, "SDDE (Software Defined Disaster Emulation)プラットフォームを用いた経路冗長化環境に対する評価実験", 情報処理学会研究報告, Mar. 2015.
 
 ## 国内学会大会等
 

--- a/scripts/convert_publications.py
+++ b/scripts/convert_publications.py
@@ -67,10 +67,10 @@ projects: []
 
 categories_ja = {
     "学術論文誌": "学術論文誌",
-    "国際会議論文": "国際会議論文",
+    "国際会議等発表": "国際会議論文",
     "著書": "著書",
-    "国内学会研究会・シンポジウム等": "国内学会研究会・シンポジウム等",
-    "国内学会大会等": "国内学会大会等",
+    "国内学会研究会・シンポジウム等発表": "国内学会研究会・シンポジウム等",
+    "国内学会大会等発表": "国内学会大会等",
     "解説・総説": "解説・総説",
     "表彰・受賞": "表彰・受賞",
     "その他": "その他"
@@ -79,10 +79,10 @@ categories_ja = {
 
 categories_en = {
     "学術論文誌": "Journal",
-    "国際会議論文": "International Conference",
+    "国際会議等発表": "International Conference",
     "著書": "Book",
-    "国内学会研究会・シンポジウム等": "Domestic Conference and Symposium",
-    "国内学会大会等": "Annual Domestic Meeting",
+    "国内学会研究会・シンポジウム等発表": "Domestic Conference and Symposium",
+    "国内学会大会等発表": "Annual Domestic Meeting",
     "解説・総説": "Survey",
     "表彰・受賞": "Award",
     "その他": "Misc"
@@ -102,7 +102,8 @@ def read_json(input_fname):
             item["authors"] = ", ".join([author["@name"] for author in
                                          publication["dc:creator"]])
             item["title"] = "\"" + publication["dc:title"]["@value"] + "\""
-            item["booktitle"] = publication["prism:publicationName"]["@value"]
+            item["booktitle"] = publication["prism:sourceName"]["@value"] or \
+                publication["prism:sourceName2"]["@value"]
             item["category"] = publication["dc:category"]["@value"]
 
             date_str = publication["prism:publicationDate"]

--- a/scripts/publications.json
+++ b/scripts/publications.json
@@ -20,8 +20,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -87,7 +92,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "IEICE Transactions on Communications",
                     "@language": "en"
                 },
@@ -117,8 +125,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -196,7 +209,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30b3\u30f3\u30d4\u30e5\u30fc\u30bf\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2"
                 },
                 "prism:volume": "36",
@@ -222,11 +238,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -352,7 +373,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Workflows in Support of Large-Scale Science (WORKS 2019)",
                     "@language": "en"
                 },
@@ -379,11 +403,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u30c7\u30e2\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30c7\u30e2\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -459,7 +488,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 37th PRAGMA workshop",
                     "@language": "en"
                 },
@@ -486,11 +518,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -556,7 +593,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Workshop on Monitoring and Analysis for High Performance Computing Systems Plus Applications (HPCMASPA 2019)",
                     "@language": "en"
                 },
@@ -583,11 +623,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -643,7 +688,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 37th PRAGMA Workshop",
                     "@language": "en"
                 },
@@ -670,11 +718,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -740,7 +793,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 37th PRAGMA Workshop",
                     "@language": "en"
                 },
@@ -767,11 +823,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -837,7 +898,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 37th PRAGMA Workshop",
                     "@language": "en"
                 },
@@ -864,11 +928,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u9023\u540d",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -934,7 +1003,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 37th PRAGMA Workshop",
                     "@language": "en"
                 },
@@ -961,11 +1033,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -1031,7 +1108,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 36th PRAGMA workshop",
                     "@language": "en"
                 },
@@ -1058,11 +1138,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -1128,7 +1213,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 36th PRAGMA Workshop",
                     "@language": "en"
                 },
@@ -1155,11 +1243,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -1215,7 +1308,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "International Conference on Optimization and Learning 2019",
                     "@language": "en"
                 },
@@ -1242,11 +1338,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -1351,7 +1452,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u7b2c33\u56de\u6570\u5024\u6d41\u4f53\u529b\u5b66\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0"
                 },
                 "prism:volume": "",
@@ -1377,11 +1481,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -1432,7 +1541,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u7814\u7a76\u5831\u544a\u30a4\u30f3\u30bf\u30fc\u30cd\u30c3\u30c8\u3068\u904b\u7528\u6280\u8853\uff08IOT\uff09"
                 },
                 "prism:volume": "2018-IOT-44",
@@ -1458,11 +1570,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -1540,7 +1657,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u7b2c5\u56de \u5b9f\u8df5\u7684IT\u6559\u80b2\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0 (rePiT2019)"
                 },
                 "prism:volume": "",
@@ -1569,8 +1689,13 @@
                     "@value": "\u8868\u5f70\u30fb\u53d7\u8cde"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -1636,7 +1761,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 36th PRAGMA Workshop",
                     "@language": "en"
                 },
@@ -1666,8 +1794,13 @@
                     "@value": "\u305d\u306e\u4ed6"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -1704,7 +1837,10 @@
                     "@value": "Japan Aerospace Exploration Agency (JAXA)",
                     "@language": "en"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "JAXA Supercomputer System Annual Report",
                     "@language": "en"
                 },
@@ -1734,8 +1870,13 @@
                     "@value": "\u305d\u306e\u4ed6"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -1821,7 +1962,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "US DOE and Japan MEXT Collaboration on Extreme Computing 2019",
                     "@language": "en"
                 },
@@ -1851,8 +1995,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -1903,7 +2052,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30b3\u30f3\u30d4\u30e5\u30fc\u30bf\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2"
                 },
                 "prism:volume": "35",
@@ -1932,8 +2084,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -1993,7 +2150,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u8ad6\u6587\u8a8c"
                 },
                 "prism:volume": "59",
@@ -2019,11 +2179,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -2089,7 +2254,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 3rd RICC-RIEC workshop",
                     "@language": "en"
                 },
@@ -2116,11 +2284,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -2176,7 +2349,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": " Proceedings of the 25th Asia-Pacific Software Engineering Conference (APSEC 2018), Poster Track",
                     "@language": "en"
                 },
@@ -2203,11 +2379,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -2263,7 +2444,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 25th Asia-Pacific Software Engineering Conference (APSEC 2018), ERA Track",
                     "@language": "en"
                 },
@@ -2290,11 +2474,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -2360,7 +2549,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 22nd International Computer Science and Engineering Conference (ICSEC 2018)",
                     "@language": "en"
                 },
@@ -2387,11 +2579,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -2467,7 +2664,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 25th Asia-Pacific Software Engineering Conference (APSEC 2018), ERA Track",
                     "@language": "en"
                 },
@@ -2494,11 +2694,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -2564,7 +2769,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 35th PRAGMA workshop",
                     "@language": "en"
                 },
@@ -2591,11 +2799,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u30c7\u30e2\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30c7\u30e2\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -2661,7 +2874,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 35th PRAGMA Workshop",
                     "@language": "en"
                 },
@@ -2688,11 +2904,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -2788,7 +3009,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "3rd IEEE/ACIS International Conference on Big Data, Cloud computing, and Data Science Engineering (BCD 2018)",
                     "@language": "en"
                 },
@@ -2815,11 +3039,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -2905,7 +3134,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 40th International Conference on Software Engineering",
                     "@language": "en"
                 },
@@ -2932,11 +3164,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -2992,7 +3229,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 34th PRAGMA workshop",
                     "@language": "en"
                 },
@@ -3019,11 +3259,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -3069,7 +3314,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 34th PRAGMA workshop",
                     "@language": "en"
                 },
@@ -3096,11 +3344,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -3151,7 +3404,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30a8\u30f3\u30b8\u30cb\u30a2\u30ea\u30f3\u30b0\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02018\u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "",
@@ -3177,11 +3433,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -3241,7 +3502,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a \u7814\u7a76\u5831\u544a\u30a4\u30f3\u30bf\u30fc\u30cd\u30c3\u30c8\u3068\u904b\u7528\u6280\u8853\uff08IOT\uff09"
                 },
                 "prism:volume": "2017-IOT-40",
@@ -3267,11 +3531,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -3327,7 +3596,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a \u7814\u7a76\u5831\u544a\u30a4\u30f3\u30bf\u30fc\u30cd\u30c3\u30c8\u3068\u904b\u7528\u6280\u8853\uff08IOT\uff09",
                     "@language": "en"
                 },
@@ -3354,11 +3626,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -3404,7 +3681,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a \u7814\u7a76\u5831\u544a\u30a4\u30f3\u30bf\u30fc\u30cd\u30c3\u30c8\u3068\u904b\u7528\u6280\u8853\uff08IOT\uff09",
                     "@language": "en"
                 },
@@ -3434,8 +3714,13 @@
                     "@value": "\u8868\u5f70\u30fb\u53d7\u8cde"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -3513,7 +3798,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u5de5\u5b66\u7814\u7a76\u4f1a"
                 },
                 "prism:volume": "",
@@ -3542,8 +3830,13 @@
                     "@value": "\u8868\u5f70\u30fb\u53d7\u8cde"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -3639,7 +3932,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "3rd IEEE/ACIS International Conference on Big Data, Cloud computing, and Data Science Engineering (BCD 2018)",
                     "@language": "en"
                 },
@@ -3669,8 +3965,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -3736,7 +4037,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Journal of Information Processing",
                     "@language": "en"
                 },
@@ -3766,8 +4070,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -3834,7 +4143,10 @@
                     "@value": "Serious Games Society",
                     "@language": "en"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "International Journal of Serious Games",
                     "@language": "en"
                 },
@@ -3864,8 +4176,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -3932,7 +4249,10 @@
                     "@value": "Springer",
                     "@language": "en"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "CSI Transactions on ICT",
                     "@language": "en"
                 },
@@ -3962,8 +4282,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -4020,7 +4345,10 @@
                     "@value": "Wiley InterScience",
                     "@language": "en"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Concurrency And Computation: Practice And Experience",
                     "@language": "en"
                 },
@@ -4050,8 +4378,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -4268,7 +4601,10 @@
                     "@value": "Wiley InterScience",
                     "@language": "en"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Concurrency And Computation: Practice And Experience",
                     "@language": "en"
                 },
@@ -4295,11 +4631,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -4355,7 +4696,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 24th Asia-Pacific Software Engineering Conference (APSEC 2017),",
                     "@language": "en"
                 },
@@ -4382,11 +4726,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -4432,7 +4781,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "9th IEEE International Conference on Cloud Computing Technology and Science (CloudCom 2017)",
                     "@language": "en"
                 },
@@ -4459,11 +4811,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -4689,7 +5046,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 2nd RICC-RIEC workshop",
                     "@language": "en"
                 },
@@ -4716,11 +5076,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -4776,7 +5141,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 15th International Conference on ICT and Knowledge Engineering",
                     "@language": "en"
                 },
@@ -4803,11 +5171,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -4873,7 +5246,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "IEEE 41st Annual Computer Software and Applications Conference (COMPSAC 2017)",
                     "@language": "en"
                 },
@@ -4900,11 +5276,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -4950,7 +5331,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "10th IEEE International Conference on Cloud Computing",
                     "@language": "en"
                 },
@@ -4977,11 +5361,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -5037,7 +5426,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA32 Workshop",
                     "@language": "en"
                 },
@@ -5064,11 +5456,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -5124,7 +5521,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA32 Workshop",
                     "@language": "en"
                 },
@@ -5151,11 +5551,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -5221,7 +5626,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": ""
                 },
                 "prism:volume": "",
@@ -5247,11 +5655,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -5367,7 +5780,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "International Symposium on Grids and Clouds 2017 (ISGC2017)",
                     "@language": "en"
                 },
@@ -5394,11 +5810,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -5464,7 +5885,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "11th International Workshop on Software Clones (IWSC) 2017",
                     "@language": "en"
                 },
@@ -5491,11 +5915,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -5551,7 +5980,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of  24rd IEEE International Conference on Software Analysis, Evolution, and Reengineering (SANER) 2017",
                     "@language": "en"
                 },
@@ -5578,11 +6010,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -5633,7 +6070,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "2017-SE-197",
@@ -5659,11 +6099,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -5714,7 +6159,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "2017-SE-197",
@@ -5740,11 +6188,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -5795,7 +6248,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "2017-SE-197",
@@ -5821,11 +6277,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -5876,7 +6337,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": ".2017-SE-197",
@@ -5902,11 +6366,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -5957,7 +6426,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "2017-SE-197",
@@ -5983,11 +6455,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -6029,7 +6506,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30a8\u30f3\u30b8\u30cb\u30a2\u30ea\u30f3\u30b0\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02017"
                 },
                 "prism:volume": "",
@@ -6055,11 +6535,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -6101,7 +6586,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30a8\u30f3\u30b8\u30cb\u30a2\u30ea\u30f3\u30b0\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02017"
                 },
                 "prism:volume": "",
@@ -6127,11 +6615,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -6191,7 +6684,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30a8\u30f3\u30b8\u30cb\u30a2\u30ea\u30f3\u30b0\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02017\u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d7"
                 },
                 "prism:volume": "",
@@ -6217,11 +6713,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -6263,7 +6764,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30a8\u30f3\u30b8\u30cb\u30a2\u30ea\u30f3\u30b0\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02017\u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d7"
                 },
                 "prism:volume": "",
@@ -6289,11 +6793,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -6344,7 +6853,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "2017-SE-196",
@@ -6370,11 +6882,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -6425,7 +6942,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "2017-SE-196",
@@ -6451,11 +6971,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f,DC\u9023\u540d",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -6521,7 +7046,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 1st. cross-disciplinary Workshop on Computing Systems, Infrastructures, and Programming",
                     "@language": "en"
                 },
@@ -6548,11 +7076,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -6612,7 +7145,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "116",
@@ -6638,11 +7174,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f,MC\u9023\u540d",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -6711,7 +7252,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30a6\u30a3\u30f3\u30bf\u30fc\u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d72017\u30fb\u30a4\u30f3\u30fb\u98db\u9a28\u9ad8\u5c71 \u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "",
@@ -6737,11 +7281,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -6792,7 +7341,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30a6\u30a3\u30f3\u30bf\u30fc\u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d72017\u30fb\u30a4\u30f3\u30fb\u98db\u9a28\u9ad8\u5c71 \u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "",
@@ -6818,11 +7370,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "5",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f,MC\u9023\u540d",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -6900,7 +7457,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u65e5\u672c\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u79d1\u5b66\u4f1a\u7b2c34\u56de\u5927\u4f1a (2017\u5e74\u5ea6) \u8b1b\u6f14\u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "",
@@ -6926,11 +7486,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "5",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -6999,7 +7564,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u65e5\u672c\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u79d1\u5b66\u4f1a\u7b2c 34 \u56de\u5927\u4f1a (2017 \u5e74\u5ea6) \u8b1b\u6f14\u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "",
@@ -7028,8 +7596,13 @@
                     "@value": "\u8868\u5f70\u30fb\u53d7\u8cde"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f,DC\u9023\u540d",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -7095,7 +7668,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Information Processing Society of Japan",
                     "@language": "en"
                 },
@@ -7125,8 +7701,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "DC\u9023\u540d",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -7252,7 +7833,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "International Journal of Information Technology",
                     "@language": "en"
                 },
@@ -7282,8 +7866,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -7330,7 +7919,10 @@
                     "@value": "Bentham Science Publishers",
                     "@language": "en"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Current Pharmaceutical Design",
                     "@language": "en"
                 },
@@ -7360,8 +7952,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -7439,7 +8036,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u8ad6\u6587\u8a8c"
                 },
                 "prism:volume": "8",
@@ -7468,8 +8068,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -7565,7 +8170,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Future Generation Computer Systems (FGCS)",
                     "@language": "en"
                 },
@@ -7592,11 +8200,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u9023\u540d,MC\u5b66\u751f,MC\u9023\u540d",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -7672,7 +8285,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proc. of 4th International Conference on Applied Computing and Information Technology (ACIT 2016)",
                     "@language": "en"
                 },
@@ -7699,11 +8315,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -7759,7 +8380,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "the 6th Workshop on Network Infrastructure Services as part of Cloud Computing (NetCloud 2016), the 8th IEEE International Conference on Cloud Computing Technology and Science (CloudCom2016)",
                     "@language": "en"
                 },
@@ -7786,11 +8410,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -7846,7 +8475,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 17th International Conference on Product-Focused Software Process Improvement (PROFES 2016)",
                     "@language": "en"
                 },
@@ -7873,11 +8505,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -7943,7 +8580,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA31 Workshop",
                     "@language": "en"
                 },
@@ -7970,11 +8610,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -8020,7 +8665,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA31 Workshop",
                     "@language": "en"
                 },
@@ -8047,11 +8695,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868,\u30c7\u30e2\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868,\u30c7\u30e2\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -8097,7 +8750,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA31 Workshop",
                     "@language": "en"
                 },
@@ -8124,11 +8780,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -8194,7 +8855,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "15th International Conference on Entertainment Computing",
                     "@language": "en"
                 },
@@ -8221,11 +8885,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -8282,7 +8951,10 @@
                     "@value": "Singapore",
                     "@language": "en"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 1st International Workshop on Software Refactoring (IWoR 2016)",
                     "@language": "en"
                 },
@@ -8309,11 +8981,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -8419,7 +9096,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "5th IIAI International Congress on Advanced Applied Informatics (IIAI-AAI)",
                     "@language": "en"
                 },
@@ -8446,11 +9126,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u30c7\u30e2\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u30c7\u30e2\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -8506,7 +9191,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "2016 IEEE 36th International Conference on Distributed Computing Systems (ICDCS)",
                     "@language": "en"
                 },
@@ -8533,11 +9221,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -8603,7 +9296,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Procedia Computer Science",
                     "@language": "en"
                 },
@@ -8630,11 +9326,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -8730,7 +9431,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proc. of 15th IEEE/ACIS International Conference on Computer and Information Science (ICIS 2016)",
                     "@language": "en"
                 },
@@ -8757,11 +9461,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -8817,7 +9526,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": ""
                 },
                 "prism:volume": "",
@@ -8843,11 +9555,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -8913,7 +9630,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 24th IEEE International Conference on Program Comprehension (ICPC 2016)",
                     "@language": "en"
                 },
@@ -8940,11 +9660,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -9040,7 +9765,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 39th IEEE International Convention on Information and Communication Technology, Electronics and Microelectronics (MIPRO 2016)",
                     "@language": "en"
                 },
@@ -9067,11 +9795,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -9157,7 +9890,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "International Symposium on Grids and Clouds 2016 (ISGC 2016)",
                     "@language": "en"
                 },
@@ -9184,11 +9920,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -9257,7 +9998,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proc. of 22nd IEEE International Conference on Software Analysis, Evolution, and Reengineering (SANER2015)"
                 },
                 "prism:volume": "",
@@ -9283,11 +10027,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u30c7\u30e2\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u30c7\u30e2\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -9329,7 +10078,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA 30 workshop"
                 },
                 "prism:volume": "",
@@ -9355,11 +10107,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -9445,7 +10202,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Disaster Management Workshop in PRAGMA30 workshop",
                     "@language": "en"
                 },
@@ -9472,11 +10232,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -9572,7 +10337,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA 30 Workshop",
                     "@language": "en"
                 },
@@ -9599,11 +10367,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -9659,7 +10432,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA 30 Workshop",
                     "@language": "en"
                 },
@@ -9686,11 +10462,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -9768,7 +10549,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30a4\u30f3\u30bf\u30fc\u30cd\u30c3\u30c8\u3068\u904b\u7528\u6280\u8853\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02016\u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "",
@@ -9794,11 +10578,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -9876,7 +10665,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30a4\u30f3\u30bf\u30fc\u30cd\u30c3\u30c8\u3068\u904b\u7528\u6280\u8853\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02016\u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "",
@@ -9902,11 +10694,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -9975,7 +10772,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u5de5\u5b66\u306e\u57fa\u790e\u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d7 (FOSE2016)"
                 },
                 "prism:volume": "",
@@ -10001,11 +10801,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -10065,7 +10870,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "2016-SE-194",
@@ -10091,11 +10899,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -10146,7 +10959,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30a8\u30f3\u30b8\u30cb\u30a2\u30ea\u30f3\u30b0\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02016"
                 },
                 "prism:volume": "",
@@ -10172,11 +10988,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -10236,7 +11057,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30a8\u30f3\u30b8\u30cb\u30a2\u30ea\u30f3\u30b0\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02016\u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "",
@@ -10262,11 +11086,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -10317,7 +11146,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "2016-SE-193",
@@ -10343,11 +11175,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -10383,7 +11220,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "IEICE Technical Report",
                     "@language": "en"
                 },
@@ -10410,11 +11250,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -10465,7 +11310,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "116",
@@ -10491,11 +11339,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -10546,7 +11399,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "2016-SE-193",
@@ -10572,11 +11428,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -10662,7 +11523,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u4fe1\u5b66\u6280\u6cd5",
                     "@language": "en"
                 },
@@ -10689,11 +11553,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u9023\u540d,MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -10769,7 +11638,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a",
                     "@language": "en"
                 },
@@ -10796,11 +11668,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -10878,7 +11755,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a \u7814\u7a76\u5831\u544a\u30a4\u30f3\u30bf\u30fc\u30cd\u30c3\u30c8\u3068\u904b\u7528\u6280\u8853 (IOT)"
                 },
                 "prism:volume": "2016-IOT-32",
@@ -10904,11 +11784,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -10986,7 +11871,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a \u7814\u7a76\u5831\u544a\u30a4\u30f3\u30bf\u30fc\u30cd\u30c3\u30c8\u3068\u904b\u7528\u6280\u8853 (IOT)"
                 },
                 "prism:volume": "2016-IOT-32",
@@ -11012,11 +11900,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -11122,7 +12015,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Annual Meeting on Advanced Computing System and Infrastructure 2016 (ACSI 2016)",
                     "@language": "en"
                 },
@@ -11152,8 +12048,13 @@
                     "@value": "\u305d\u306e\u4ed6"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u57fa\u8abf\u30fb\u62db\u5f85\u8b1b\u6f14",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u57fa\u8abf\u8b1b\u6f14,\u62db\u5f85\u8b1b\u6f14",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -11179,7 +12080,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": ""
                 },
                 "prism:volume": "",
@@ -11205,11 +12109,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -11286,7 +12195,10 @@
                     "@value": "Springer",
                     "@language": "en"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Sustained Simulation Performance 2015",
                     "@language": "en"
                 },
@@ -11313,11 +12225,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -11403,7 +12320,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 5th International Workshop on Network-aware Data Management(NDM\u201915)",
                     "@language": "en"
                 },
@@ -11430,11 +12350,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -11490,7 +12415,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA Workshop on International Clouds for Data Science (PRAGMA-ICDS 2015)",
                     "@language": "en"
                 },
@@ -11517,11 +12445,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u9023\u540d",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -11697,7 +12630,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA Workshop on International Clouds for Data Science (PRAGMA-ICDS 2015)",
                     "@language": "en"
                 },
@@ -11724,11 +12660,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u30c7\u30e2\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30c7\u30e2\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -11794,7 +12735,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA 29 workshop",
                     "@language": "en"
                 },
@@ -11821,11 +12765,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -11901,7 +12850,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "15th International Symposium on Communications and Information Technologies (ISCIT\u201915)",
                     "@language": "en"
                 },
@@ -11928,11 +12880,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u9023\u540d",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -12058,7 +13015,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "International Conference Research and Innovation (ICCCRI)",
                     "@language": "en"
                 },
@@ -12085,11 +13045,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -12145,7 +13110,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA 29 Workshop",
                     "@language": "en"
                 },
@@ -12172,11 +13140,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868,\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868,\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -12262,7 +13235,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA 29 Workshop",
                     "@language": "en"
                 },
@@ -12289,11 +13265,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868,\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868,\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -12349,7 +13330,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA 29 Workshop",
                     "@language": "en"
                 },
@@ -12376,11 +13360,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -12416,7 +13405,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "ESEC/FSE 2015 Proceedings of the 2015 10th Joint Meeting on Foundations of Software Engineering",
                     "@language": "en"
                 },
@@ -12443,11 +13435,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f,DC\u9023\u540d",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -12503,7 +13500,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "11th IEEE International Conference on eScience",
                     "@language": "en"
                 },
@@ -12530,11 +13530,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -12610,7 +13615,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "11th IEEE International Conference on eScience2015",
                     "@language": "en"
                 },
@@ -12637,11 +13645,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -12717,7 +13730,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proc. 12th Working Conference on Mining Software Repositories (MSR)",
                     "@language": "en"
                 },
@@ -12744,11 +13760,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -12804,7 +13825,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proc. 12th Working Conference on Mining Software Repositories (MSR)",
                     "@language": "en"
                 },
@@ -12831,11 +13855,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -12901,7 +13930,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA 28 Workshop",
                     "@language": "en"
                 },
@@ -12928,11 +13960,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -12978,7 +14015,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA 28 Workshop",
                     "@language": "en"
                 },
@@ -13005,11 +14045,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -13045,7 +14090,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA 28 Workshop",
                     "@language": "en"
                 },
@@ -13072,11 +14120,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -13112,7 +14165,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Pragma 28 Workshop",
                     "@language": "en"
                 },
@@ -13139,11 +14195,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868,\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868,\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -13189,7 +14250,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA 28 Workshop",
                     "@language": "en"
                 },
@@ -13216,11 +14280,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -13296,7 +14365,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA 28 Workshop",
                     "@language": "en"
                 },
@@ -13323,11 +14395,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u30c7\u30e2\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30c7\u30e2\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -13433,7 +14510,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA 28 Workshop",
                     "@language": "en"
                 },
@@ -13460,11 +14540,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f,DC\u9023\u540d",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -13540,7 +14625,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of The 22nd IEEE International Conference on Software Analysis, Evolution, and Reengineering (SANER\u201915)",
                     "@language": "en"
                 },
@@ -13567,11 +14655,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -13649,7 +14742,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u4fe1\u5b66\u6280\u5831"
                 },
                 "prism:volume": "115",
@@ -13675,11 +14771,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -13703,7 +14804,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u7b2c1\u56deRICC - RIEC \u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d7"
                 },
                 "prism:volume": "",
@@ -13729,11 +14833,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "\u305d\u306e\u4ed6",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -13802,7 +14911,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30a8\u30f3\u30b8\u30cb\u30a2\u30ea\u30f3\u30b0\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02015\u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "",
@@ -13828,11 +14940,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -13883,7 +15000,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "2015-IOT-31",
@@ -13909,11 +15029,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -13955,7 +15080,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u7d44\u8fbc\u307f\u30b7\u30b9\u30c6\u30e0\u6280\u8853\u306b\u95a2\u3059\u308b\u30b5\u30de\u30fc\u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d7\u3000(SWTEST17)"
                 },
                 "prism:volume": "",
@@ -13981,11 +15109,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -14027,7 +15160,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u5831\u544a"
                 },
                 "prism:volume": "SS2015",
@@ -14053,11 +15189,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -14099,7 +15240,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u5831\u544a"
                 },
                 "prism:volume": "115",
@@ -14125,11 +15269,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -14207,7 +15356,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "2014-IOT-28",
@@ -14233,11 +15385,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -14261,7 +15418,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u7b2c 7 \u56de\u5730\u57df\u9593\u30a4\u30f3\u30bf\u30fc\u30af\u30e9\u30a6\u30c9\u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d7"
                 },
                 "prism:volume": "",
@@ -14287,11 +15447,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -14369,7 +15534,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u7814\u7a76\u5831\u544a, ICM2014-39"
                 },
                 "prism:volume": "114",
@@ -14395,11 +15563,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -14477,7 +15650,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u7814\u7a76\u5831\u544a, IN2014-120"
                 },
                 "prism:volume": "114",
@@ -14503,11 +15679,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -14585,7 +15766,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u7814\u7a76\u5831\u544a, NS2014-161"
                 },
                 "prism:volume": "114",
@@ -14611,11 +15795,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -14693,7 +15882,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u7814\u7a76\u5831\u544a, IA2014-81"
                 },
                 "prism:volume": "114",
@@ -14719,11 +15911,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -14799,7 +15996,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proc. of IPSJ/SIGSE Winter Workshop 2015 in Ginowan",
                     "@language": "en"
                 },
@@ -14829,8 +16029,13 @@
                     "@value": "\u30de\u30b9\u30b3\u30df\u5831\u9053"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -14863,7 +16068,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u65e5\u520a\u5de5\u696d\u65b0\u805e"
                 },
                 "prism:volume": "",
@@ -14892,8 +16100,13 @@
                     "@value": "\u8868\u5f70\u30fb\u53d7\u8cde"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -15069,7 +16282,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA Workshop on International Clouds for Data Science (PRAGMA-ICDS 2015)",
                     "@language": "en"
                 },
@@ -15099,8 +16315,13 @@
                     "@value": "\u8868\u5f70\u30fb\u53d7\u8cde"
                 },
                 "dc:authorAttr": "\u305d\u306e\u4ed6",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -15169,7 +16390,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\uff12\uff10\uff11\uff15"
                 },
                 "prism:volume": "",
@@ -15198,8 +16422,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -15305,7 +16534,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The Review of Socionetwork Strategies",
                     "@language": "en"
                 },
@@ -15335,8 +16567,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -15423,7 +16660,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u8ad6\u6587\u8a8c"
                 },
                 "prism:volume": "J97-D",
@@ -15452,8 +16692,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "DC\u9023\u540d",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -15504,7 +16749,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30b3\u30f3\u30d4\u30e5\u30fc\u30bf\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2"
                 },
                 "prism:volume": "31",
@@ -15530,11 +16778,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -15640,7 +16893,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Emerging Issues in Cloud Workshop, 6th IEEE International Conference and Workshops on Cloud Computing Technology and Science (CloudCom2014)",
                     "@language": "en"
                 },
@@ -15667,11 +16923,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -15777,7 +17038,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Emerging Issues in Cloud Workshop, the 6th IEEE International Conference on Cloud Computing Technology and Science (CloudCom 2014)",
                     "@language": "en"
                 },
@@ -15804,11 +17068,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -15904,7 +17173,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Innovating the Network for Data-Intensive Science Workshop (INDIS2014), the International Conference for High Performance Computing, networking, Storage and Analysis (SC14)",
                     "@language": "en"
                 },
@@ -15931,11 +17203,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -15991,7 +17268,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "2014 Workshop on Assurance Cases for Software-intensive Systems (ASSURE 2014)",
                     "@language": "en"
                 },
@@ -16018,11 +17298,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -16068,7 +17353,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "2014 Workshop on Assurance Cases for Software-intensive Systems (ASSURE 2014)",
                     "@language": "en"
                 },
@@ -16095,11 +17383,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -16135,7 +17428,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The Fourth Workshop on Open Systems Dependability (WOSD2014\uff09",
                     "@language": "en"
                 },
@@ -16162,11 +17458,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -16232,7 +17533,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA 27 Workshop",
                     "@language": "en"
                 },
@@ -16259,11 +17563,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -16319,7 +17628,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA 27 Workshop",
                     "@language": "en"
                 },
@@ -16346,11 +17658,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -16416,7 +17733,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA 27 Workshop",
                     "@language": "en"
                 },
@@ -16443,11 +17763,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -16513,7 +17838,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA 27 Workshop",
                     "@language": "en"
                 },
@@ -16540,11 +17868,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868,\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868,\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -16640,7 +17973,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA 27 Workshop",
                     "@language": "en"
                 },
@@ -16667,11 +18003,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f,DC\u9023\u540d",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -16757,7 +18098,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 30th International Conference on Software Maintenance and Evolution (ICSME 2014)",
                     "@language": "en"
                 },
@@ -16784,11 +18128,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -16854,7 +18203,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "12th IEEE International Conference on Dependable, Autonomic and Secure Computing (DASC 2014)",
                     "@language": "en"
                 },
@@ -16881,11 +18233,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -16931,7 +18288,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 18th International Computer Science and Engineering Conference (ICSEC2014) ",
                     "@language": "en"
                 },
@@ -16958,11 +18318,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -17038,7 +18403,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 38th IEEE Annual International Computers, Software and Applications Conference",
                     "@language": "en"
                 },
@@ -17065,11 +18433,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -17135,7 +18508,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "7th International Workshop on Cooperative and Human Aspects of Software Engineering (CHASE 2014)\u00a0",
                     "@language": "en"
                 },
@@ -17162,11 +18538,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f,MC\u9023\u540d",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -17252,7 +18633,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proc. of 11th Working Conference on Mining Software Repositories (MSR2014)",
                     "@language": "en"
                 },
@@ -17279,11 +18663,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -17379,7 +18768,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA 26 Workshop",
                     "@language": "en"
                 },
@@ -17406,11 +18798,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -17496,7 +18893,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA 26 Workshop",
                     "@language": "en"
                 },
@@ -17523,11 +18923,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -17563,7 +18968,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA 26 Workshop",
                     "@language": "en"
                 },
@@ -17590,11 +18998,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -17660,7 +19073,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA 26 Workshop",
                     "@language": "en"
                 },
@@ -17687,11 +19103,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u30c7\u30e2\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30c7\u30e2\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -17747,7 +19168,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA 26 Workshop",
                     "@language": "en"
                 },
@@ -17774,11 +19198,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -17834,7 +19263,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a \u7814\u7a76\u5831\u544a\u30a8\u30f3\u30bf\u30c6\u30a4\u30f3\u30e1\u30f3\u30c8\u30b3\u30f3\u30d4\u30e5\u30fc\u30c6\u30a3\u30f3\u30b0\uff08EC\uff09",
                     "@language": "en"
                 },
@@ -17861,11 +19293,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -17943,7 +19380,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u7814\u7a76\u5831\u544a, IA2014-70"
                 },
                 "prism:volume": "114",
@@ -17969,11 +19409,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -18051,7 +19496,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a \u30a4\u30f3\u30bf\u30fc\u30cd\u30c3\u30c8\u3068\u904b\u7528\u6280\u8853\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0(IOTS)2014\u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "",
@@ -18077,11 +19525,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -18159,7 +19612,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "2014-IOT-27",
@@ -18185,11 +19641,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -18225,7 +19686,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "SICE Annual Conference 2014",
                     "@language": "en"
                 },
@@ -18252,11 +19716,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f,DC\u9023\u540d,MC\u9023\u540d",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -18322,7 +19791,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30a8\u30f3\u30b8\u30cb\u30a2\u30ea\u30f3\u30b0\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02014\u8ad6\u6587\u96c6",
                     "@language": "en"
                 },
@@ -18349,11 +19821,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u9023\u540d",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -18413,7 +19890,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": ""
                 },
                 "prism:volume": "",
@@ -18439,11 +19919,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -18489,7 +19974,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "IPSJ SIG Notes 2014-HPC-145",
                     "@language": "en"
                 },
@@ -18516,11 +20004,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -18553,7 +20046,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "IPSJ SIG Notes 2014-HPC-145"
                 },
                 "prism:volume": "",
@@ -18579,11 +20075,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -18649,7 +20150,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "IPSJ SIG Notes 2014-HPC-145",
                     "@language": "en"
                 },
@@ -18676,11 +20180,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -18875,7 +20384,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "2014-SE-184/2014-EMB-33",
@@ -18901,11 +20413,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -18974,7 +20491,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u7b2c4\u56de\u5730\u57df\u9593\u30a4\u30f3\u30bf\u30fc\u30af\u30e9\u30a6\u30c9\u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d7"
                 },
                 "prism:volume": "",
@@ -19000,11 +20520,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -19050,7 +20575,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u7b2c5\u56deD-Case\u7814\u7a76\u4f1a",
                     "@language": "en"
                 },
@@ -19080,8 +20608,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -19157,7 +20690,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The Review of Socionetwork Strategies",
                     "@language": "en"
                 },
@@ -19187,8 +20723,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -19244,7 +20785,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Journal of Software: Evolution and Process",
                     "@language": "en"
                 },
@@ -19274,8 +20818,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -19341,7 +20890,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "INFORMATION - An International Interdisciplinary Journal",
                     "@language": "en"
                 },
@@ -19371,8 +20923,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -19432,7 +20989,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u8ad6\u6587\u8a8c"
                 },
                 "prism:volume": "54",
@@ -19461,8 +21021,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -19513,7 +21078,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u8ad6\u6587\u8a8c"
                 },
                 "prism:volume": "54",
@@ -19539,11 +21107,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -19619,7 +21192,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 19th IEEE International Conference on Networks (ICON2013)",
                     "@language": "en"
                 },
@@ -19646,11 +21222,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -19746,7 +21327,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 19th IEEE International Conference On Networks (ICON 2013)",
                     "@language": "en"
                 },
@@ -19773,11 +21357,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u30c7\u30e2\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30c7\u30e2\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -19843,7 +21432,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Pragma25 Workshop",
                     "@language": "en"
                 },
@@ -19870,11 +21462,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u30c7\u30e2\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30c7\u30e2\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -19970,7 +21567,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Pragma25 Workshop",
                     "@language": "en"
                 },
@@ -19997,11 +21597,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -20077,7 +21682,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "9th IEEE International Conference on eScience",
                     "@language": "en"
                 },
@@ -20104,11 +21712,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -20204,7 +21817,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 6th Workshop on UnConventional High Performance Computing 2013",
                     "@language": "en"
                 },
@@ -20231,11 +21847,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -20331,7 +21952,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Doctoral Symposium, IEEE Computer Software and Applications Conference (COMPSAC2013)",
                     "@language": "en"
                 },
@@ -20358,11 +21982,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -20448,7 +22077,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 4th IEEE International Workshop on High-Speed Network and Computing Environment",
                     "@language": "en"
                 },
@@ -20475,11 +22107,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -20535,7 +22172,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 14th International Conference on Product-Focused Software Development and Process Improvement",
                     "@language": "en"
                 },
@@ -20562,11 +22202,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -20632,7 +22277,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 21st IEEE International Conference on Program Comprehension",
                     "@language": "en"
                 },
@@ -20659,11 +22307,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -20729,7 +22382,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 7th International Workshop on Software Clones",
                     "@language": "en"
                 },
@@ -20756,11 +22412,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u9023\u540d,MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -20836,7 +22497,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 10th Working Conference on Mining Software Repositories",
                     "@language": "en"
                 },
@@ -20863,11 +22527,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -20933,7 +22602,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 10th International Joint Conference on Computer Science and Software Engineering (JCSSE'13)",
                     "@language": "en"
                 },
@@ -20960,11 +22632,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u30c7\u30e2\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u30c7\u30e2\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -21030,7 +22707,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "AOSD 2013 Companion",
                     "@language": "en"
                 },
@@ -21057,11 +22737,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868,\u30c7\u30e2\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868,\u30c7\u30e2\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -21197,7 +22882,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA24 Workshop",
                     "@language": "en"
                 },
@@ -21224,11 +22912,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -21254,7 +22947,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA Cloud Computing and Software-Defined Networking (SDN) Technology Workshop",
                     "@language": "en"
                 },
@@ -21284,8 +22980,13 @@
                     "@value": "\u8457\u66f8"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -21462,7 +23163,10 @@
                     "@value": "IOS Press",
                     "@language": "en"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Cloud Computing and Big Data, volume 23 of Advances in Parallel Computing",
                     "@language": "en"
                 },
@@ -21489,11 +23193,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -21549,7 +23258,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u7814\u7a76\u5831\u544a",
                     "@language": "en"
                 },
@@ -21576,11 +23288,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -21604,7 +23321,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "RICC - NII \u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d7"
                 },
                 "prism:volume": "",
@@ -21630,11 +23350,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u9023\u540d",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -21685,7 +23410,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "113",
@@ -21711,11 +23439,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -21757,7 +23490,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u7b2c20\u56de\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u5de5\u5b66\u306e\u57fa\u790e\u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d7 (FOSE 2013)"
                 },
                 "prism:volume": "",
@@ -21783,11 +23519,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u9023\u540d,MC\u5b66\u751f",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -21838,7 +23579,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "2013-SE-182",
@@ -21864,11 +23608,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -21924,7 +23673,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u7b2c4\u56deD-Case\u5b9f\u8a3c\u8a55\u4fa1\u7814\u7a76\u4f1a",
                     "@language": "en"
                 },
@@ -21951,11 +23703,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -21997,7 +23754,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u7b2c4\u56deD-Case\u5b9f\u8a3c\u8a55\u4fa1\u7814\u7a76\u4f1a"
                 },
                 "prism:volume": "",
@@ -22023,11 +23783,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -22060,7 +23825,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u7b2c4\u56deD-Case\u5b9f\u8a3c\u8a55\u4fa1\u7814\u7a76\u4f1a"
                 },
                 "prism:volume": "",
@@ -22086,11 +23854,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -22150,7 +23923,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u65e5\u672c\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u79d1\u5b66\u4f1a\u7b2c30\u56de\u5927\u4f1a\u8b1b\u6f14\u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "",
@@ -22176,11 +23952,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u9023\u540d,MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -22231,7 +24012,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u65e5\u672c\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u79d1\u5b66\u4f1a\u7b2c30\u56de\u5927\u4f1a\u8b1b\u6f14\u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "",
@@ -22257,11 +24041,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -22307,7 +24096,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30a8\u30f3\u30b8\u30cb\u30a2\u30ea\u30f3\u30b0\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02013(SES2013)",
                     "@language": "en"
                 },
@@ -22334,11 +24126,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -22362,7 +24159,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30a8\u30f3\u30b8\u30cb\u30a2\u30ea\u30f3\u30b0\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02013(SES2013)"
                 },
                 "prism:volume": "",
@@ -22388,11 +24188,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -22443,7 +24248,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "2013-SE-181",
@@ -22469,11 +24277,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -22578,7 +24391,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u7814\u7a76\u5831\u544a\u30cf\u30a4\u30d1\u30d5\u30a9\u30fc\u30de\u30f3\u30b9\u30b3\u30f3\u30d4\u30e5\u30fc\u30c6\u30a3\u30f3\u30b0\uff08HPC\uff09"
                 },
                 "prism:volume": "2013-HPC-140",
@@ -22604,11 +24420,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -22695,7 +24516,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u7814\u7a76\u5831\u544a\u30cf\u30a4\u30d1\u30d5\u30a9\u30fc\u30de\u30f3\u30b9\u30b3\u30f3\u30d4\u30e5\u30fc\u30c6\u30a3\u30f3\u30b0\uff08HPC\uff09"
                 },
                 "prism:volume": "2013-HPC-140",
@@ -22721,11 +24545,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f,MC\u9023\u540d",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -22794,7 +24623,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u5831\u544a"
                 },
                 "prism:volume": "113",
@@ -22820,11 +24652,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -22893,7 +24730,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u5831\u544a"
                 },
                 "prism:volume": "113",
@@ -22919,11 +24759,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -22974,7 +24819,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u5831\u544a"
                 },
                 "prism:volume": "113",
@@ -23000,11 +24848,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -23046,7 +24899,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u5831\u544a"
                 },
                 "prism:volume": "113",
@@ -23072,11 +24928,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -23127,7 +24988,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u5831\u544a"
                 },
                 "prism:volume": "113",
@@ -23153,11 +25017,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u9023\u540d",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -23217,7 +25086,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u7b2c2\u56de\u5730\u57df\u9593\u30a4\u30f3\u30bf\u30fc\u30af\u30e9\u30a6\u30c9\u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d7"
                 },
                 "prism:volume": "",
@@ -23243,11 +25115,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -23307,7 +25184,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u7814\u7a76\u5831\u544a\u6559\u80b2\u5b66\u7fd2\u652f\u63f4\u60c5\u5831\u30b7\u30b9\u30c6\u30e0 (CLE)"
                 },
                 "prism:volume": "2013-CLE-10",
@@ -23333,11 +25213,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -23460,7 +25345,10 @@
                 "dc:publisher": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a \u30a4\u30f3\u30bf\u30fc\u30cd\u30c3\u30c8\u3068\u904b\u7528\u6280\u8853\uff08IOT\uff09"
                 },
                 "prism:volume": "Vol.2013-IOT-20",
@@ -23486,11 +25374,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -23577,7 +25470,10 @@
                 "dc:publisher": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a \u30a4\u30f3\u30bf\u30fc\u30cd\u30c3\u30c8\u3068\u904b\u7528\u6280\u8853\uff08IOT\uff09"
                 },
                 "prism:volume": "2013-IOT-20",
@@ -23606,8 +25502,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -23649,7 +25550,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30b3\u30f3\u30d4\u30e5\u30fc\u30bf \u30bd\u30d5\u30c8\u30a6\u30a7\u30a2"
                 },
                 "prism:volume": "29",
@@ -23678,8 +25582,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -23739,7 +25648,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u8ad6\u6587\u8a8c\uff1a\u30b3\u30f3\u30d4\u30e5\u30fc\u30c6\u30a3\u30f3\u30b0\u30b7\u30b9\u30c6\u30e0 \u7b2c40\u53f7"
                 },
                 "prism:volume": "5",
@@ -23768,8 +25680,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -23836,7 +25753,10 @@
                     "@value": "\u65e5\u672c\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u79d1\u5b66\u4f1a",
                     "@language": "en"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30b3\u30f3\u30d4\u30e5\u30fc\u30bf\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2",
                     "@language": "en"
                 },
@@ -23866,8 +25786,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -23924,7 +25849,10 @@
                     "@value": "\u65e5\u672c\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u79d1\u5b66\u4f1a",
                     "@language": "en"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30b3\u30f3\u30d4\u30e5\u30fc\u30bf\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2",
                     "@language": "en"
                 },
@@ -23954,8 +25882,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -24012,7 +25945,10 @@
                     "@value": "John Wiley & Sons",
                     "@language": "en"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Journal of Software: Evolution and Process",
                     "@language": "en"
                 },
@@ -24042,8 +25978,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -24110,7 +26051,10 @@
                     "@value": "Computer Society of the Republic of China",
                     "@language": "en"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Journal of Computers",
                     "@language": "en"
                 },
@@ -24140,8 +26084,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -24174,7 +26123,10 @@
                 "dc:publisher": {
                     "@value": "\u65e5\u672c\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u79d1\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30b3\u30f3\u30d4\u30e5\u30fc\u30bf\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2"
                 },
                 "prism:volume": "29",
@@ -24203,8 +26155,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -24246,7 +26203,10 @@
                 "dc:publisher": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u8ad6\u6587\u8a8c"
                 },
                 "prism:volume": "53",
@@ -24272,11 +26232,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u9023\u540d,MC\u5b66\u751f,MC\u9023\u540d",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -24362,7 +26327,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 19th Asia-Pacific Software Engineering Conference",
                     "@language": "en"
                 },
@@ -24389,11 +26357,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -24449,7 +26422,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 19th Asia-Pacific Software Engineering Conference",
                     "@language": "en"
                 },
@@ -24476,11 +26452,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -24536,7 +26517,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 19th Asia-Pacific Software Engineering Conference Workshops",
                     "@language": "en"
                 },
@@ -24563,11 +26547,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -24633,7 +26622,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 3rd International Workshop on Ubiquitous Computing & Applications",
                     "@language": "en"
                 },
@@ -24660,11 +26652,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f,DC\u9023\u540d,MC\u9023\u540d",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -24750,7 +26747,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Supplemental Proceedings of the IEEE 23rd International Symposium on Software Reliability Engineering",
                     "@language": "en"
                 },
@@ -24777,11 +26777,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -24847,7 +26852,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "4th International Workshop on Empirical Software Engineering in Practice",
                     "@language": "en"
                 },
@@ -24874,11 +26882,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u9023\u540d,MC\u5b66\u751f",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -24984,7 +26997,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA 23 Workshop",
                     "@language": "en"
                 },
@@ -25011,11 +27027,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -25101,7 +27122,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA 23 Workshop",
                     "@language": "en"
                 },
@@ -25128,11 +27152,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -25218,7 +27247,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of 2012 IEEE 36th International Conference on Computer Software and Applications Workshops (The Sixth Middleware Architecture in the Internet (MidArch 2012))",
                     "@language": "en"
                 },
@@ -25245,11 +27277,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -25345,7 +27382,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 6th International Workshop on Software Clones",
                     "@language": "en"
                 },
@@ -25372,11 +27412,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -25432,7 +27477,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 6th International Workshop on Software Clones",
                     "@language": "en"
                 },
@@ -25459,11 +27507,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -25509,7 +27562,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 5th Workshop on Refactoring Tools",
                     "@language": "en"
                 },
@@ -25536,11 +27592,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u30c7\u30e2\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30c7\u30e2\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -25646,7 +27707,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 22th PRAGMA Workshop",
                     "@language": "en"
                 },
@@ -25673,11 +27737,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -25783,7 +27852,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA22 Workshop",
                     "@language": "en"
                 },
@@ -25810,11 +27882,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -25900,7 +27977,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PRAGMA 22 Workshop",
                     "@language": "en"
                 },
@@ -25927,11 +28007,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u9023\u540d",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -25977,7 +28062,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 16th European Conference on Software Maintenance and Reengineering ",
                     "@language": "en"
                 },
@@ -26007,8 +28095,13 @@
                     "@value": "\u8457\u66f8"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -26195,7 +28288,10 @@
                     "@value": "CRC Press",
                     "@language": "en"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": ""
                 },
                 "prism:volume": "",
@@ -26221,11 +28317,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -26258,7 +28359,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u7b2c10\u56de \u30c7\u30a3\u30da\u30f3\u30c0\u30d6\u30eb\u30b7\u30b9\u30c6\u30e0\u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d7 (DSW 2012)"
                 },
                 "prism:volume": "",
@@ -26284,11 +28388,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -26312,7 +28421,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u7b2c10\u56de \u30c7\u30a3\u30da\u30f3\u30c0\u30d6\u30eb\u30b7\u30b9\u30c6\u30e0\u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d7 (DSW 2012)"
                 },
                 "prism:volume": "",
@@ -26338,11 +28450,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -26393,7 +28510,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "SDN Japan"
                 },
                 "prism:volume": "",
@@ -26419,11 +28539,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -26501,7 +28626,10 @@
                 "dc:publisher": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u7b2c194\u56de\u8a08\u7b97\u6a5f\u30a2\u30fc\u30ad\u30c6\u30af\u30c1\u30e3\u30fb\u7b2c137\u56de\u30cf\u30a4\u30d1\u30d5\u30a9\u30fc\u30de\u30f3\u30b9\u30b3\u30f3\u30d4\u30e5\u30fc\u30c6\u30a3\u30f3\u30b0\u5408\u540c\u7814\u7a76\u767a\u8868\u4f1a\uff08HOKKE-20\uff09"
                 },
                 "prism:volume": "2012-HPC-137",
@@ -26527,11 +28655,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -26582,7 +28715,10 @@
                 "dc:publisher": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "112",
@@ -26608,11 +28744,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u9023\u540d,MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -26663,7 +28804,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "2012-SE-178",
@@ -26689,11 +28833,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -26735,7 +28884,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "2012-SE-178",
@@ -26761,11 +28913,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -26821,7 +28978,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u5831\u544a",
                     "@language": "en"
                 },
@@ -26848,11 +29008,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -26894,7 +29059,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u5168\u56fd\u5171\u540c\u5229\u7528\u60c5\u5831\u57fa\u76e4\u30bb\u30f3\u30bf\u30fc \u7814\u7a76\u958b\u767a\u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "",
@@ -26920,11 +29088,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -26975,7 +29148,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30a8\u30f3\u30b8\u30cb\u30a2\u30ea\u30f3\u30b0\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02012 (SES2012) \u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "",
@@ -27001,11 +29177,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -27065,7 +29246,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30a8\u30f3\u30b8\u30cb\u30a2\u30ea\u30f3\u30b0\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02012 (SES2012) \u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "",
@@ -27091,11 +29275,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -27155,7 +29344,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30a8\u30f3\u30b8\u30cb\u30a2\u30ea\u30f3\u30b0\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02012 (SES2012) \u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "",
@@ -27181,11 +29373,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -27227,7 +29424,10 @@
                 "dc:publisher": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u5831\u544a"
                 },
                 "prism:volume": "112",
@@ -27253,11 +29453,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u57fa\u8abf\u30fb\u62db\u5f85\u8b1b\u6f14",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u57fa\u8abf\u8b1b\u6f14,\u62db\u5f85\u8b1b\u6f14",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -27281,7 +29486,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": ""
                 },
                 "prism:volume": "",
@@ -27307,11 +29515,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -27371,7 +29584,10 @@
                 "dc:publisher": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "2012-SE-177",
@@ -27397,11 +29613,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -27470,7 +29691,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "2012-SE-176",
@@ -27496,11 +29720,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -27524,7 +29753,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02012"
                 },
                 "prism:volume": "",
@@ -27550,11 +29782,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -27614,7 +29851,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u7b2c121\u56de\u30b7\u30b9\u30c6\u30e0\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u3068\u30aa\u30da\u30ec\u30fc\u30c6\u30a3\u30f3\u30b0\u30fb\u30b7\u30b9\u30c6\u30e0\u7814\u7a76\u4f1a"
                 },
                 "prism:volume": "",
@@ -27640,11 +29880,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -27704,7 +29949,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u5148\u9032\u7684\u8a08\u7b97\u57fa\u76e4\u30b7\u30b9\u30c6\u30e0\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0(sacsis2012)"
                 },
                 "prism:volume": "",
@@ -27730,11 +29978,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -27794,7 +30047,10 @@
                 "dc:publisher": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u5831\u544a"
                 },
                 "prism:volume": "111",
@@ -27820,11 +30076,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -27875,7 +30136,10 @@
                 "dc:publisher": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u5831\u544a"
                 },
                 "prism:volume": "111",
@@ -27901,11 +30165,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -27929,7 +30198,10 @@
                 "dc:publisher": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30a6\u30a4\u30f3\u30bf\u30fc\u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d72012\u30fb\u30a4\u30f3\u30fb\u7435\u7436\u6e56 \u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "",
@@ -27955,11 +30227,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "5",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -28010,7 +30287,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u5e73\u621024\u5e74\u5ea6 \u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u95a2\u897f\u652f\u90e8 \u652f\u90e8\u5927\u4f1a \u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "",
@@ -28039,8 +30319,13 @@
                     "@value": "NAIST\u30c6\u30af\u30cb\u30ab\u30eb\u30ec\u30dd\u30fc\u30c8"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -28064,7 +30349,10 @@
                 "dc:publisher": {
                     "@value": "\u5948\u826f\u5148\u7aef\u79d1\u5b66\u6280\u8853\u5927\u5b66\u9662\u5927\u5b66"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": ""
                 },
                 "prism:volume": "",
@@ -28093,8 +30381,13 @@
                     "@value": "\u8868\u5f70\u30fb\u53d7\u8cde"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -28160,7 +30453,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "4th International Workshop on Empirical Software Engineering in Practice ",
                     "@language": "en"
                 },
@@ -28190,8 +30486,13 @@
                     "@value": "\u8868\u5f70\u30fb\u53d7\u8cde"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -28242,7 +30543,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30aa\u30e9\u30af\u30eb"
                 },
                 "prism:volume": "",
@@ -28271,8 +30575,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -28328,7 +30637,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Journal of Information Processing Systems",
                     "@language": "en"
                 },
@@ -28358,8 +30670,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -28392,7 +30709,10 @@
                 "dc:publisher": {
                     "@value": "\u65e5\u672c\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u79d1\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": " \u30b3\u30f3\u30d4\u30e5\u30fc\u30bf\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2"
                 },
                 "prism:volume": "28",
@@ -28421,8 +30741,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -28500,7 +30825,10 @@
                 "dc:publisher": {
                     "@value": "\u65e5\u672c\u77e5\u80fd\u60c5\u5831\u30d5\u30a1\u30b8\u30a3\u5b66\u4f1a\u8a8c"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u77e5\u80fd\u3068\u60c5\u5831"
                 },
                 "prism:volume": "",
@@ -28529,8 +30857,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "\u30dd\u30b9\u30c9\u30af",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -28563,7 +30896,10 @@
                 "dc:publisher": {
                     "@value": "\u65e5\u672c\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u79d1\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30b3\u30f3\u30d4\u30e5\u30fc\u30bf\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2"
                 },
                 "prism:volume": "28",
@@ -28592,8 +30928,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -28635,7 +30976,10 @@
                 "dc:publisher": {
                     "@value": "\u65e5\u672c\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u79d1\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30b3\u30f3\u30d4\u30e5\u30fc\u30bf\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2"
                 },
                 "prism:volume": "28",
@@ -28661,11 +31005,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -28721,7 +31070,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of The 6th International Conference on Ubiquitous Information Technologies & Applications",
                     "@language": "en"
                 },
@@ -28748,11 +31100,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -28818,7 +31175,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of The 6th International Conference on Ubiquitous Information Technologies and Applications",
                     "@language": "en"
                 },
@@ -28845,11 +31205,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -28905,7 +31270,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Supplemental Proceedings of the IEEE 22nd International Symposium on Software Reliability Engineering",
                     "@language": "en"
                 },
@@ -28932,11 +31300,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -29002,7 +31375,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 2011 IEEE Conference on Granular Computing (GrC 2011)",
                     "@language": "en"
                 },
@@ -29029,11 +31405,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -29069,7 +31450,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 2011 IEEE Conference on Granular Computing (GrC 2011)",
                     "@language": "en"
                 },
@@ -29096,11 +31480,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -29156,7 +31545,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 2011 IEEE Conference on Granular Computing (GrC 2011)",
                     "@language": "en"
                 },
@@ -29183,11 +31575,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -29253,7 +31650,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 3rd International Workshop on Empirical Software Engineering in Practice",
                     "@language": "en"
                 },
@@ -29280,11 +31680,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -29350,7 +31755,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 18th Working Conference on Reverse Engineering ",
                     "@language": "en"
                 },
@@ -29377,11 +31785,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -29437,7 +31850,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "the 2011 ITS World Congress",
                     "@language": "en"
                 },
@@ -29464,11 +31880,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -29534,7 +31955,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "the 2011 ITS World Congress,",
                     "@language": "en"
                 },
@@ -29561,11 +31985,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -29631,7 +32060,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "the 2011 ITS World Congress",
                     "@language": "en"
                 },
@@ -29658,11 +32090,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -29728,7 +32165,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 2nd Asian Conference on Pattern Languages of Programs ",
                     "@language": "en"
                 },
@@ -29755,11 +32195,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -29825,7 +32270,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 21th PRAGMA Workshop",
                     "@language": "en"
                 },
@@ -29852,11 +32300,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -29942,7 +32395,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 21th PRAGMA Workshop",
                     "@language": "en"
                 },
@@ -29969,11 +32425,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -30029,7 +32490,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Joint Workshop on Software Science and Engineering",
                     "@language": "en"
                 },
@@ -30056,11 +32520,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -30116,7 +32585,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Joint Workshop on Software Science and Engineering",
                     "@language": "en"
                 },
@@ -30143,11 +32615,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -30194,7 +32671,10 @@
                     "@value": "Springer-Verlag",
                     "@language": "en"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of PROFES2011 (12th International Conference, Product Focused Software Development and Process Improvement) ",
                     "@language": "en"
                 },
@@ -30221,11 +32701,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -30291,7 +32776,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 5th International Workshop on Software Clones (IWSC 2011)",
                     "@language": "en"
                 },
@@ -30318,11 +32806,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -30388,7 +32881,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 10th International Conference on Aspected-Oriented Software Development (AOSD'11)",
                     "@language": "en"
                 },
@@ -30415,11 +32911,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -30479,7 +32980,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a (2011-EMB-23(3))"
                 },
                 "prism:volume": "",
@@ -30505,11 +33009,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -30566,7 +33075,10 @@
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a",
                     "@language": "en"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a",
                     "@language": "en"
                 },
@@ -30593,11 +33105,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -30639,7 +33156,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30a8\u30f3\u30b8\u30cb\u30a2\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0 2011 (SES 2011) \u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "",
@@ -30665,11 +33185,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -30711,7 +33236,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30a8\u30f3\u30b8\u30cb\u30a2\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0 2011 (SES 2011) \u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "",
@@ -30737,11 +33265,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -30765,7 +33298,10 @@
                 "dc:publisher": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30a8\u30f3\u30b8\u30cb\u30a2\u30ea\u30f3\u30b0\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02011 \u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d7\u300c\u958b\u767a\u30de\u30cd\u30b8\u30e1\u30f3\u30c8\u3092\u53d6\u308a\u5dfb\u304f\u74b0\u5883\u3068\u8ab2\u984c\u300d"
                 },
                 "prism:volume": "",
@@ -30791,11 +33327,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -30846,7 +33387,10 @@
                 "dc:publisher": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "111",
@@ -30872,11 +33416,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u57fa\u8abf\u30fb\u62db\u5f85\u8b1b\u6f14,\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u57fa\u8abf\u8b1b\u6f14,\u62db\u5f85\u8b1b\u6f14,\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -30909,7 +33458,10 @@
                 "dc:publisher": {
                     "@value": "\u60c5\u5831\u30b5\u30fc\u30d3\u30b9\u7523\u696d\u5354\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30d7\u30ed\u30bb\u30b9\u30a8\u30f3\u30b8\u30cb\u30a2\u30ea\u30f3\u30b0\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02011"
                 },
                 "prism:volume": "",
@@ -30935,11 +33487,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -30999,7 +33556,10 @@
                 "dc:publisher": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "2011-SE-173",
@@ -31025,11 +33585,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -31098,7 +33663,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u65e5\u672c\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u79d1\u5b66\u4f1a\u7b2c12\u56de\u30a4\u30f3\u30bf\u30fc\u30cd\u30c3\u30c8\u30c6\u30af\u30ce\u30ed\u30b8\u30fc\u7814\u7a76\u4f1a\uff08WIT2011\uff09"
                 },
                 "prism:volume": "",
@@ -31124,11 +33692,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "\u30dd\u30b9\u30c9\u30af",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -31152,7 +33725,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30a6\u30a3\u30f3\u30bf\u30fc\u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d7 2011\u30fb\u30a4\u30f3\u30fb\u4fee\u5584\u5bfa \u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "",
@@ -31178,11 +33754,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -31233,7 +33814,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30a6\u30a3\u30f3\u30bf\u30fc\u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d72011\u30fb\u30a4\u30f3\u30fb\u4fee\u5584\u5bfa \u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "2011",
@@ -31259,11 +33843,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -31323,7 +33912,10 @@
                 "dc:publisher": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30a6\u30a3\u30f3\u30bf\u30fc\u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d72011\u30fb\u30a4\u30f3\u30fb\u4fee\u5584\u5bfa \u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "2011",
@@ -31349,11 +33941,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "5",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -31404,7 +34001,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u5927\u5b66ICT\u63a8\u9032\u5354\u8b70\u4f1a2011\u5e74\u5ea6\u5e74\u6b21\u5927\u4f1a\u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "",
@@ -31430,11 +34030,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "5",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -31485,7 +34090,10 @@
                 "dc:publisher": {
                     "@value": "\u65e5\u672c\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u79d1\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u65e5\u672c\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u79d1\u5b66\u4f1a\u7b2c28\u56de\u5927\u4f1a \u8b1b\u6f14\u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "",
@@ -31511,11 +34119,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "5",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u9023\u540d",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -31557,7 +34170,10 @@
                 "dc:publisher": {
                     "@value": "\u65e5\u672c\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u79d1\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u65e5\u672c\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u79d1\u5b66\u4f1a\u7b2c28\u56de\u5927\u4f1a \u8b1b\u6f14\u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "",
@@ -31583,11 +34199,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "5",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -31654,7 +34275,10 @@
                     "@value": "\u65e5\u672c\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u79d1\u5b66\u4f1a",
                     "@language": "en"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u65e5\u672c\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u79d1\u5b66\u4f1a\u7b2c28\u56de\u5927\u4f1a \u8b1b\u6f14\u8ad6\u6587\u96c6",
                     "@language": "en"
                 },
@@ -31681,11 +34305,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "5",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f,\u30dd\u30b9\u30c9\u30af",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -31736,7 +34365,10 @@
                 "dc:publisher": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a 2011\u5e74\u7dcf\u5408\u5927\u4f1a \u60c5\u5831\u30b7\u30b9\u30c6\u30e0\u8b1b\u6f14\u8ad6\u6587\u96c62"
                 },
                 "prism:volume": "",
@@ -31765,8 +34397,13 @@
                     "@value": "\u8868\u5f70\u30fb\u53d7\u8cde"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -31790,7 +34427,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a \u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u5de5\u5b66\u7814\u7a76\u4f1a"
                 },
                 "prism:volume": "",
@@ -31819,8 +34459,13 @@
                     "@value": "\u8868\u5f70\u30fb\u53d7\u8cde"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -31862,7 +34507,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a \u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u5de5\u5b66\u7814\u7a76\u4f1a"
                 },
                 "prism:volume": "",
@@ -31891,8 +34539,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "DC\u9023\u540d",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -31934,7 +34587,10 @@
                 "dc:publisher": {
                     "@value": "\u682a\u5f0f\u4f1a\u793e\u30aa\u30fc\u30e0\u793e"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "SEC journal"
                 },
                 "prism:volume": "",
@@ -31963,8 +34619,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "DC\u9023\u540d",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -32024,7 +34685,10 @@
                 "dc:publisher": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u8ad6\u6587\u8a8c"
                 },
                 "prism:volume": "51",
@@ -32053,8 +34717,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -32132,7 +34801,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u8ad6\u6587\u8a8c"
                 },
                 "prism:volume": "J93-D",
@@ -32158,11 +34830,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -32228,7 +34905,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the International Workshop on Empirical Software Engineering in Practice 2010 (IWESEP 2010)",
                     "@language": "en"
                 },
@@ -32255,11 +34935,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -32315,7 +35000,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the International Workshop on Empirical Software Engineering in Practice 2010 (IWESEP 2010)",
                     "@language": "en"
                 },
@@ -32342,11 +35030,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f,\u30dd\u30b9\u30c9\u30af",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -32402,7 +35095,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the International Workshop on Empirical Software Engineering in Practice 2010 (IWESEP 2010)",
                     "@language": "en"
                 },
@@ -32429,11 +35125,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f,DC\u9023\u540d,\u30dd\u30b9\u30c9\u30af",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -32490,7 +35191,10 @@
                     "@value": "Springer",
                     "@language": "en"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PROFES 2010 (Product-Focused Software Process Improvement)",
                     "@language": "en"
                 },
@@ -32517,11 +35221,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -32568,7 +35277,10 @@
                     "@value": "ACM",
                     "@language": "en"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 4th International Workshop on Software Clones (IWSC 2010)",
                     "@language": "en"
                 },
@@ -32595,11 +35307,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -32641,7 +35358,10 @@
                 "dc:publisher": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "110",
@@ -32667,11 +35387,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -32713,7 +35438,10 @@
                 "dc:publisher": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "110",
@@ -32739,11 +35467,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "\u30dd\u30b9\u30c9\u30af",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -32776,7 +35509,10 @@
                 "dc:publisher": {
                     "@value": "\u8fd1\u4ee3\u79d1\u5b66\u793e"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u5de5\u5b66\u306e\u57fa\u790eXVII"
                 },
                 "prism:volume": "",
@@ -32802,11 +35538,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -32857,7 +35598,10 @@
                 "dc:publisher": {
                     "@value": "\u8fd1\u4ee3\u79d1\u5b66\u793e"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u5de5\u5b66\u306e\u57fa\u790eXVII"
                 },
                 "prism:volume": "",
@@ -32883,11 +35627,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f,MC\u9023\u540d",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -32947,7 +35696,10 @@
                 "dc:publisher": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u5831\u544a, \u30e2\u30d0\u30a4\u30eb\u30de\u30eb\u30c1\u30e1\u30c7\u30a3\u30a2\u901a\u4fe1\u7814\u7a76\u5c02\u9580\u59d4\u54e1\u4f1a,MoMuC2006-55"
                 },
                 "prism:volume": "",
@@ -32973,11 +35725,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -33028,7 +35785,10 @@
                 "dc:publisher": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "110",
@@ -33054,11 +35814,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -33118,7 +35883,10 @@
                 "dc:publisher": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "110",
@@ -33144,11 +35912,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -33190,7 +35963,10 @@
                 "dc:publisher": {
                     "@value": "\u8fd1\u4ee3\u79d1\u5b66\u793e"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30a8\u30f3\u30b8\u30cb\u30a2\u30ea\u30f3\u30b0\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02010"
                 },
                 "prism:volume": "",
@@ -33216,11 +35992,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -33262,7 +36043,10 @@
                 "dc:publisher": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "110",
@@ -33288,11 +36072,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -33343,7 +36132,10 @@
                 "dc:publisher": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "110",
@@ -33369,11 +36161,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "5",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f,\u30dd\u30b9\u30c9\u30af",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -33424,7 +36221,10 @@
                 "dc:publisher": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u5e73\u621022\u5e74\u5ea6 \u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u95a2\u897f\u652f\u90e8 \u652f\u90e8\u5927\u4f1a \u8b1b\u6f14\u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "",
@@ -33450,11 +36250,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "5",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -33496,7 +36301,10 @@
                 "dc:publisher": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u5e73\u621022\u5e74\u5ea6\u3000\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u95a2\u897f\u652f\u90e8 \u652f\u90e8\u5927\u4f1a \u8b1b\u6f14\u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "",
@@ -33525,8 +36333,13 @@
                     "@value": "\u8868\u5f70\u30fb\u53d7\u8cde"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -33550,7 +36363,10 @@
                 "dc:publisher": {
                     "@value": "\u8fd1\u4ee3\u79d1\u5b66\u793e"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u5de5\u5b66\u7814\u7a76\u4f1a"
                 },
                 "prism:volume": "",
@@ -33579,8 +36395,13 @@
                     "@value": "\u305d\u306e\u4ed6"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u57fa\u8abf\u30fb\u62db\u5f85\u8b1b\u6f14",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u57fa\u8abf\u8b1b\u6f14,\u62db\u5f85\u8b1b\u6f14",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -33606,7 +36427,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "9th CREST Open Workshop",
                     "@language": "en"
                 },
@@ -33636,8 +36460,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -33715,7 +36544,10 @@
                 "dc:publisher": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u8ad6\u6587\u8a8cD"
                 },
                 "prism:volume": "J92-D",
@@ -33744,8 +36576,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "DC\u9023\u540d",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -33814,7 +36651,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "SEC journal"
                 },
                 "prism:volume": "5",
@@ -33840,11 +36680,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u9023\u540d",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -33920,7 +36765,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "16th Asia-Pacific Software Engineering Conference (APSEC2009)",
                     "@language": "en"
                 },
@@ -33947,11 +36795,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -33997,7 +36850,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 3rd International Workshop on Software Patterns and Quality (SPAQu'09)",
                     "@language": "en"
                 },
@@ -34024,11 +36880,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868,\u30c7\u30e2\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868,\u30c7\u30e2\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -34114,7 +36975,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "16th Working Conference on Reverse Engineering  (WCRE2009)",
                     "@language": "en"
                 },
@@ -34141,11 +37005,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -34191,7 +37060,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "2009 International Workshop on Empirical Software Engineering in Practice (IWESEP 2009)",
                     "@language": "en"
                 },
@@ -34218,11 +37090,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -34273,7 +37150,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "109",
@@ -34299,11 +37179,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -34354,7 +37239,10 @@
                 "dc:publisher": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "109",
@@ -34380,11 +37268,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -34462,7 +37355,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "109",
@@ -34488,11 +37384,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -34561,7 +37462,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u5de5\u5b66\u306e\u57fa\u790eXVI"
                 },
                 "prism:volume": "",
@@ -34587,11 +37491,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -34642,7 +37551,10 @@
                 "dc:publisher": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "2009-SE-166",
@@ -34668,11 +37580,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -34741,7 +37658,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7b2c166\u56de\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u5de5\u5b66\u7814\u7a76\u4f1a, \u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "2009-SE-166",
@@ -34767,11 +37687,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u9023\u540d,MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -34822,7 +37747,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a \u4fe1\u5b66\u6280\u5831, KBSE2009-24"
                 },
                 "prism:volume": "109",
@@ -34848,11 +37776,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u9023\u540d,MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -34912,7 +37845,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30a8\u30f3\u30b8\u30cb\u30a2\u30ea\u30f3\u30b0\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02009"
                 },
                 "prism:volume": "",
@@ -34938,11 +37874,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -34993,7 +37934,10 @@
                 "dc:publisher": {
                     "@value": "\u8fd1\u4ee3\u79d1\u5b66\u793e"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30a8\u30f3\u30b8\u30cb\u30a2\u30ea\u30f3\u30b0\u6700\u524d\u7dda2009"
                 },
                 "prism:volume": "",
@@ -35019,11 +37963,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -35065,7 +38014,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30a8\u30f3\u30b8\u30cb\u30a2\u30ea\u30f3\u30b0\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02009 \u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d73 \u30bd\u30fc\u30b9\u30b3\u30fc\u30c9\u306e\u985e\u4f3c\u6027"
                 },
                 "prism:volume": "",
@@ -35091,11 +38043,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -35137,7 +38094,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30a8\u30f3\u30b8\u30cb\u30a2\u30ea\u30f3\u30b0\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02009 \u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d73 \u30bd\u30fc\u30b9\u30b3\u30fc\u30c9\u306e\u985e\u4f3c\u6027"
                 },
                 "prism:volume": "",
@@ -35163,11 +38123,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -35209,7 +38174,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30a8\u30f3\u30b8\u30cb\u30a2\u30ea\u30f3\u30b0\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02009 \u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d74 \u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u958b\u767a\u30de\u30cd\u30b8\u30e1\u30f3\u30c8\u306e\u305f\u3081\u306e\u6e2c\u5b9a\u3068\u5206\u6790"
                 },
                 "prism:volume": "",
@@ -35235,11 +38203,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -35281,7 +38254,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u5831\u544a, \u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30b5\u30a4\u30a8\u30f3\u30b9\u7814\u7a76\u4f1a"
                 },
                 "prism:volume": "109",
@@ -35307,11 +38283,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -35353,7 +38334,10 @@
                 "dc:publisher": {
                     "@value": "\u793e\u56e3\u6cd5\u4eba \u60c5\u5831\u51e6\u7406\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30a6\u30a4\u30f3\u30bf\u30fc\u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d72009\u30fb\u30a4\u30f3\u30fb\u5bae\u5d0e\u8ad6\u6587\u96c6 (\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u30b7\u30ea\u30fc\u30ba)"
                 },
                 "prism:volume": "2009",
@@ -35379,11 +38363,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -35416,7 +38405,10 @@
                 "dc:publisher": {
                     "@value": "\u793e\u56e3\u6cd5\u4eba \u60c5\u5831\u51e6\u7406\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30a6\u30a4\u30f3\u30bf\u30fc\u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d72009\u30fb\u30a4\u30f3\u30fb\u5bae\u5d0e\u8ad6\u6587\u96c6 (\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u30b7\u30ea\u30fc\u30ba)"
                 },
                 "prism:volume": "2009",
@@ -35445,8 +38437,13 @@
                     "@value": "\u8868\u5f70\u30fb\u53d7\u8cde"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -35470,7 +38467,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": ""
                 },
                 "prism:volume": "",
@@ -35499,8 +38499,13 @@
                     "@value": "\u305d\u306e\u4ed6"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -35524,7 +38529,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a \u7b2c165\u56de\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u5de5\u5b66\u7814\u7a76\u4f1a"
                 },
                 "prism:volume": "",
@@ -35550,11 +38558,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -35610,7 +38623,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of 2nd Workshop on Accountability and Traceability in Global Software Engineering (ATGSE 2008)",
                     "@language": "en"
                 },
@@ -35637,11 +38653,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -35717,7 +38738,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 4th International Project Management Conference (ProMAC2008)",
                     "@language": "en"
                 },
@@ -35744,11 +38768,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -35814,7 +38843,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 4th International Conference on Open Source Systems (OSS2008)",
                     "@language": "en"
                 },
@@ -35841,11 +38873,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -35911,7 +38948,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "9th International Conference on Product Focused Software Process Improvement (PROFES2008)",
                     "@language": "en"
                 },
@@ -35941,8 +38981,13 @@
                     "@value": "\u8457\u66f8"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -35975,7 +39020,10 @@
                 "dc:publisher": {
                     "@value": "\u8fd1\u4ee3\u79d1\u5b66\u793e"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": ""
                 },
                 "prism:volume": "",
@@ -36004,8 +39052,13 @@
                     "@value": "\u8457\u66f8"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -36029,7 +39082,10 @@
                 "dc:publisher": {
                     "@value": "\u65e5\u7d4cBP\u793e"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": ""
                 },
                 "prism:volume": "",
@@ -36058,8 +39114,13 @@
                     "@value": "\u8457\u66f8"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -36083,7 +39144,10 @@
                 "dc:publisher": {
                     "@value": "\u65e5\u7d4cBP\u793e"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": ""
                 },
                 "prism:volume": "",
@@ -36112,8 +39176,13 @@
                     "@value": "\u8457\u66f8"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -36146,7 +39215,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": ""
                 },
                 "prism:volume": "",
@@ -36175,8 +39247,13 @@
                     "@value": "\u8457\u66f8"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -36344,7 +39421,10 @@
                 "dc:publisher": {
                     "@value": "\u30a2\u30b9\u30ad\u30fc"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": ""
                 },
                 "prism:volume": "",
@@ -36370,11 +39450,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f,MC\u9023\u540d",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -36443,7 +39528,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a \u4fe1\u5b66\u6280\u5831, SS2008-39"
                 },
                 "prism:volume": "108",
@@ -36469,11 +39557,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -36515,7 +39608,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u5de5\u5b66\u306e\u57fa\u790eXV"
                 },
                 "prism:volume": "",
@@ -36541,11 +39637,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u9023\u540d",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -36596,7 +39697,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u7b2c16\u56de\u30a4\u30f3\u30bf\u30e9\u30af\u30c6\u30a3\u30d6\u30b7\u30b9\u30c6\u30e0\u3068\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u306b\u95a2\u3059\u308b\u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d7 (WISS 2008)"
                 },
                 "prism:volume": "",
@@ -36622,11 +39726,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -36713,7 +39822,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u5831\u544a, \u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30b5\u30a4\u30a8\u30f3\u30b9\u7814\u7a76\u4f1a"
                 },
                 "prism:volume": "",
@@ -36739,11 +39851,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -36803,7 +39920,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a \u7b2c161\u56de\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u5de5\u5b66\u7814\u7a76\u4f1a"
                 },
                 "prism:volume": "",
@@ -36829,11 +39949,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -36884,7 +40009,10 @@
                 "dc:publisher": {
                     "@value": "\u6771\u6d0b\u5927\u5b66"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u54c1\u8cea\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02008"
                 },
                 "prism:volume": "",
@@ -36910,11 +40038,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -36974,7 +40107,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u6e2c\u5b9a\u3068\u898b\u7a4d\u3082\u308a\u306b\u95a2\u3059\u308b\u77e5\u8b58\u5171\u6709\uff08SES2008 \u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d7\uff09"
                 },
                 "prism:volume": "",
@@ -37000,11 +40136,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -37055,7 +40196,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u958b\u767a\u306e\u30d1\u30bf\u30fc\u30f3\u3068\u30a2\u30fc\u30ad\u30c6\u30af\u30c1\u30e3\uff08SES2008 \u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d7\uff09"
                 },
                 "prism:volume": "",
@@ -37081,11 +40225,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -37136,7 +40285,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30a8\u30f3\u30b8\u30cb\u30a2\u30ea\u30f3\u30b0\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02008"
                 },
                 "prism:volume": "",
@@ -37162,11 +40314,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u9023\u540d,MC\u5b66\u751f,MC\u9023\u540d,\u30dd\u30b9\u30c9\u30af",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -37244,7 +40401,10 @@
                 "dc:publisher": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a \u4fe1\u5b66\u6280\u5831"
                 },
                 "prism:volume": "108",
@@ -37270,11 +40430,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -37325,7 +40490,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30a4\u30f3\u30bf\u30e9\u30af\u30b7\u30e7\u30f32008"
                 },
                 "prism:volume": "",
@@ -37351,11 +40519,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -37406,7 +40579,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30a4\u30f3\u30bf\u30e9\u30af\u30b7\u30e7\u30f32008"
                 },
                 "prism:volume": "",
@@ -37432,11 +40608,16 @@
                 "dc:subDepartment": "\u305d\u306e\u4ed6\u90e8\u7f72",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -37523,7 +40704,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a,\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u5de5\u5b66\u7814\u7a76\u4f1a"
                 },
                 "prism:volume": "2008-SE-159",
@@ -37549,11 +40733,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u7121\u3057",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -37577,7 +40766,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": ""
                 },
                 "prism:volume": "2008",
@@ -37603,11 +40795,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -37631,7 +40828,10 @@
                 "dc:publisher": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u30b7\u30ea\u30fc\u30ba"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30a6\u30a4\u30f3\u30bf\u30fc\u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d72008\u30fb\u30a4\u30f3\u30fb\u9053\u5f8c \u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "2008",
@@ -37657,11 +40857,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -37694,7 +40899,10 @@
                 "dc:publisher": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u30b7\u30ea\u30fc\u30ba"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30a6\u30a4\u30f3\u30bf\u30fc\u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d72008\u30fb\u30a4\u30f3\u30fb\u9053\u5f8c \u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "2008",
@@ -37720,11 +40928,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -37766,7 +40979,10 @@
                 "dc:publisher": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u30b7\u30ea\u30fc\u30ba"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30a6\u30a4\u30f3\u30bf\u30fc\u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d72008\u30fb\u30a4\u30f3\u30fb\u9053\u5f8c \u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "2008",
@@ -37792,11 +41008,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "5",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u9023\u540d,MC\u5b66\u751f,MC\u9023\u540d,\u30dd\u30b9\u30c9\u30af",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -37874,7 +41095,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a \u7b2c70\u56de\u5168\u56fd\u5927\u4f1a"
                 },
                 "prism:volume": "",
@@ -37900,11 +41124,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "5",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -37964,7 +41193,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a \u7b2c70\u56de\u5168\u56fd\u5927\u4f1a"
                 },
                 "prism:volume": "",
@@ -37993,8 +41225,13 @@
                     "@value": "NAIST\u30c6\u30af\u30cb\u30ab\u30eb\u30ec\u30dd\u30fc\u30c8"
                 },
                 "dc:authorAttr": "DC\u9023\u540d,MC\u5b66\u751f",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -38045,7 +41282,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "NAIST-IS-TR2008008"
                 },
                 "prism:volume": "",
@@ -38074,8 +41314,13 @@
                     "@value": "NAIST\u30c6\u30af\u30cb\u30ab\u30eb\u30ec\u30dd\u30fc\u30c8"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -38162,7 +41407,10 @@
                     "@value": "\u5948\u826f\u5148\u7aef\u79d1\u5b66\u6280\u8853\u5927\u5b66\u9662\u5927\u5b66",
                     "@language": "en"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Information Science Technical Report, \u5948\u826f\u5148\u7aef\u79d1\u5b66\u6280\u8853\u5927\u5b66\u9662\u5927\u5b66",
                     "@language": "en"
                 },
@@ -38192,8 +41440,13 @@
                     "@value": "\u8868\u5f70\u30fb\u53d7\u8cde"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -38217,7 +41470,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u72ec\u7acb\u884c\u653f\u6cd5\u4eba\u60c5\u5831\u51e6\u7406\u6a5f\u69cb"
                 },
                 "prism:volume": "",
@@ -38246,8 +41502,13 @@
                     "@value": "\u305d\u306e\u4ed6"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -38273,7 +41534,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The Seventh China System and Software Process Improvement Annual Meeting (CSPIN-CSSPI 2008)",
                     "@language": "en"
                 },
@@ -38300,11 +41564,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -38360,7 +41629,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of the 14th Asia-Pacific Software Engineering Conference (Research Poster)",
                     "@language": "en"
                 },
@@ -38387,11 +41659,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -38427,7 +41704,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proc. of Workshop on Accountability and Traceability in Global Software Engineering ",
                     "@language": "en"
                 },
@@ -38454,11 +41734,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -38505,7 +41790,10 @@
                     "@value": "IPSJ/SIGSE",
                     "@language": "en"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proc. of Workshop on Accountability and Traceability in Global Software Engineering",
                     "@language": "en"
                 },
@@ -38532,11 +41820,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -38573,7 +41866,10 @@
                     "@value": "IPSJ/SIGSE",
                     "@language": "en"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proc. of Workshop on Accountability and Traceability in Global Software Engineering",
                     "@language": "en"
                 },
@@ -38600,11 +41896,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -38661,7 +41962,10 @@
                     "@value": "IPSJ/SIGSE",
                     "@language": "en"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proc. of Workshop on Accountability and Traceability in Global Software Engineering",
                     "@language": "en"
                 },
@@ -38688,11 +41992,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -38729,7 +42038,10 @@
                     "@value": "IPSJ/SIGSE",
                     "@language": "en"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proc. of Workshop on Accountability and Traceability in Global Software Engineering",
                     "@language": "en"
                 },
@@ -38756,11 +42068,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -38807,7 +42124,10 @@
                     "@value": "IPSJ/SIGSE",
                     "@language": "en"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proc. of 1st International Workshop on Software Patterns and Quality (SPAQu'07)",
                     "@language": "en"
                 },
@@ -38834,11 +42154,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u9023\u540d",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -38914,7 +42239,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of 1st Workshop on Measurement-based Cockpits for Distributed Software and Systems Engineering Projects (SOFTPIT 2007)",
                     "@language": "en"
                 },
@@ -38944,8 +42272,13 @@
                     "@value": "\u8457\u66f8"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -38969,7 +42302,10 @@
                 "dc:publisher": {
                     "@value": "\u65e5\u7d4cBP\u793e"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": ""
                 },
                 "prism:volume": "",
@@ -38995,11 +42331,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "COE",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -39068,7 +42409,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u7814\u7a76\u5831\u544a"
                 },
                 "prism:volume": "107",
@@ -39094,11 +42438,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "5",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -39167,7 +42516,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u65e5\u672c\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u79d1\u5b66\u4f1a \u7b2c24\u56de\u5927\u4f1a"
                 },
                 "prism:volume": "",
@@ -39193,11 +42545,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "5",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u5927\u4f1a\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u9023\u540d,MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -39266,7 +42623,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u65e5\u672c\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u79d1\u5b66\u4f1a\u7b2c24\u56de\u5927\u4f1a\u8ad6\u6587\u96c6"
                 },
                 "prism:volume": "",
@@ -39295,8 +42655,13 @@
                     "@value": "\u8868\u5f70\u30fb\u53d7\u8cde"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -39320,7 +42685,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a"
                 },
                 "prism:volume": "",
@@ -39349,8 +42717,13 @@
                     "@value": "\u305d\u306e\u4ed6"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u57fa\u8abf\u30fb\u62db\u5f85\u8b1b\u6f14",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u57fa\u8abf\u8b1b\u6f14,\u62db\u5f85\u8b1b\u6f14",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -39374,7 +42747,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u5de5\u5b66\u5de5\u623f \u7b2c8, 9\u56de\u30bb\u30df\u30ca\u30fc\u3000\u30b3\u30fc\u30c9\u30af\u30ed\u30fc\u30f3\u691c\u51fa\u6280\u8853\u3068\u305d\u306e\u5fdc\u7528"
                 },
                 "prism:volume": "",
@@ -39403,8 +42779,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -39446,7 +42827,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u8ad6\u6587\u8a8c D"
                 },
                 "prism:volume": "89",
@@ -39472,11 +42856,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -39542,7 +42931,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "The 13th Asia Pacific Software Engineering Conference (APSEC06) ",
                     "@language": "en"
                 },
@@ -39569,11 +42961,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u57fa\u8abf\u30fb\u62db\u5f85\u8b1b\u6f14",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u57fa\u8abf\u8b1b\u6f14,\u62db\u5f85\u8b1b\u6f14",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -39599,7 +42996,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "SEA International Forum in Kyoto",
                     "@language": "en"
                 },
@@ -39626,11 +43026,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -39696,7 +43101,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "PROMAC2006",
                     "@language": "en"
                 },
@@ -39723,11 +43131,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u9023\u540d",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "COE",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -39783,7 +43196,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proc. of 7th International Conference on Product Focused Software Process Improvement (Profes2006)",
                     "@language": "en"
                 },
@@ -39810,11 +43226,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -39860,7 +43281,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of International Software Process Workshop and International Workshop on Software Process Simulation and Modeling (SPW/ProSim 2006)",
                     "@language": "en"
                 },
@@ -39890,8 +43314,13 @@
                     "@value": "\u8457\u66f8"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "COE",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -39924,7 +43353,10 @@
                 "dc:publisher": {
                     "@value": "\u65e5\u7d4cBP\u793e"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "IT \u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u306e\u300c\u898b\u3048\u308b\u5316\u300d\uff5e\u4e0b\u6d41\u5de5\u7a0b\u7de8\uff5e"
                 },
                 "prism:volume": "",
@@ -39950,11 +43382,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u9023\u540d,MC\u9023\u540d",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -40023,7 +43460,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7b2c154\u56de\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u5de5\u5b66\u7814\u7a76\u4f1a"
                 },
                 "prism:volume": "",
@@ -40049,11 +43489,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -40104,7 +43549,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7b2c154\u56de\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u5de5\u5b66\u7814\u7a76\u4f1a"
                 },
                 "prism:volume": "",
@@ -40130,11 +43578,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -40212,7 +43665,10 @@
                 "dc:publisher": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u5831\u544a, \u30e2\u30d0\u30a4\u30eb\u30de\u30eb\u30c1\u30e1\u30c7\u30a3\u30a2\u901a\u4fe1\u7814\u7a76\u5c02\u9580\u59d4\u54e1\u4f1a"
                 },
                 "prism:volume": "",
@@ -40238,11 +43694,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -40302,7 +43763,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30a8\u30f3\u30b8\u30ea\u30a2\u30ea\u30f3\u30b0\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02006"
                 },
                 "prism:volume": "",
@@ -40328,11 +43792,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "COE",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -40383,7 +43852,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30a8\u30f3\u30b8\u30cb\u30a2\u30ea\u30f3\u30b0\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02006"
                 },
                 "prism:volume": "",
@@ -40409,11 +43881,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f,DC\u9023\u540d",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -40464,7 +43941,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30a8\u30f3\u30b8\u30cb\u30a2\u30ea\u30f3\u30b0\u6700\u524d\u7dda2006"
                 },
                 "prism:volume": "",
@@ -40490,11 +43970,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -40518,7 +44003,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Workshop on Leveraging Web2.0 Technologies in Software Development Environments (WebSDE)"
                 },
                 "prism:volume": "",
@@ -40544,11 +44032,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -40590,7 +44083,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u4fe1\u983c\u6027\u30ef\u30fc\u30af\u30b7\u30e7\u30c3\u30d7\u7b2c\u4e09\u56de\u7814\u7a76\u4f1a(FORCE2006)"
                 },
                 "prism:volume": "",
@@ -40619,8 +44115,13 @@
                     "@value": "\u305d\u306e\u4ed6"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u57fa\u8abf\u30fb\u62db\u5f85\u8b1b\u6f14",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u57fa\u8abf\u8b1b\u6f14,\u62db\u5f85\u8b1b\u6f14",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -40644,7 +44145,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u5e73\u6210\uff11\uff18\u5e74\u5ea6\u9ad8\u54c1\u8cea\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u6280\u8853\u4ea4\u6d41\u4f1a\u7b2c\uff13\u56de\u4f8b\u4f1a"
                 },
                 "prism:volume": "",
@@ -40673,8 +44177,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "COE",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -40716,7 +44225,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u8ad6\u6587\u8a8c"
                 },
                 "prism:volume": "46",
@@ -40742,11 +44254,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u30dd\u30b9\u30bf\u30fc\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -40802,7 +44319,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "International Symposium on Empirical Software Engineering",
                     "@language": "en"
                 },
@@ -40829,11 +44349,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -40875,7 +44400,10 @@
                 "dc:publisher": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u6280\u8853\u5831\u544a, \u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30b5\u30a4\u30a8\u30f3\u30b9\u7814\u7a76\u4f1a"
                 },
                 "prism:volume": "",
@@ -40901,11 +44429,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -40965,7 +44498,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30b7\u30f3\u30dd\u30b8\u30a6\u30e02005"
                 },
                 "prism:volume": "",
@@ -40991,11 +44527,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "4",
-                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49"
+                    "@value": "\u56fd\u5185\u5b66\u4f1a\u7814\u7a76\u4f1a\u30fb\u30b7\u30f3\u30dd\u30b8\u30a6\u30e0\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -41082,7 +44623,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u7814\u7a76\u5831\u544a,\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u5de5\u5b66"
                 },
                 "prism:volume": "147",
@@ -41111,8 +44655,13 @@
                     "@value": "\u305d\u306e\u4ed6"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u57fa\u8abf\u30fb\u62db\u5f85\u8b1b\u6f14",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "\u57fa\u8abf\u8b1b\u6f14,\u62db\u5f85\u8b1b\u6f14",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -41136,7 +44685,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u7b2c23\u56de\u3000SEA\u95a2\u897f\u30d7\u30ed\u30bb\u30b9\u5206\u79d1\u4f1a"
                 },
                 "prism:volume": "",
@@ -41165,8 +44717,13 @@
                     "@value": "\u305d\u306e\u4ed6"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "COE",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -41280,7 +44837,10 @@
                 "dc:publisher": {
                     "@value": "\u682a\u5f0f\u4f1a\u793e\u30b3\u30f3\u30d4\u30e5\u30fc\u30bf\u30fb\u30a8\u30fc\u30b8\u793e"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "ISBN4-87566-314-5"
                 },
                 "prism:volume": "",
@@ -41306,11 +44866,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u9023\u540d,MC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "COE",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -41366,7 +44931,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proc. Workshop on Software Product Archiving and Retrieving System",
                     "@language": "en"
                 },
@@ -41396,8 +44964,13 @@
                     "@value": "\u8457\u66f8"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -41434,7 +45007,10 @@
                     "@value": "Springer",
                     "@language": "en"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Lecture Notes in Computer Science, Vol. 3009, 584p,ISBN: 3-540-21421-6 ",
                     "@language": "en"
                 },
@@ -41464,8 +45040,13 @@
                     "@value": "\u89e3\u8aac\u30fb\u7dcf\u8aac"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -41498,7 +45079,10 @@
                 "dc:publisher": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u8a8c"
                 },
                 "prism:volume": "87",
@@ -41524,11 +45108,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "COE",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -41594,7 +45183,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of 6th Joint Workshop on System Development (JWSD2003), CD-ROM Edition",
                     "@language": "en"
                 },
@@ -41624,8 +45216,13 @@
                     "@value": "\u89e3\u8aac\u30fb\u7dcf\u8aac"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -41649,7 +45246,10 @@
                 "dc:publisher": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u96fb\u5b50\u60c5\u5831\u901a\u4fe1\u5b66\u4f1a\u8a8c"
                 },
                 "prism:volume": "86",
@@ -41675,11 +45275,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "COE",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -41726,7 +45331,10 @@
                     "@value": "Lecture Notes in Computer Science 2559 Springer-Verlag",
                     "@language": "en"
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of 4th International Conference on Product Focused Software Process Improvement (PROFES 2002)",
                     "@language": "en"
                 },
@@ -41753,11 +45361,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "DC\u5b66\u751f",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "COE",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -41813,7 +45426,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of International Symposium on Future Software Technology 2002 (ISFST2002), (CD-ROM for PC)",
                     "@language": "en"
                 },
@@ -41840,11 +45456,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "COE",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -41900,7 +45521,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings of International Symposium on Empirical Software Engineering (ISESE2002)",
                     "@language": "en"
                 },
@@ -41927,11 +45551,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "\u53e3\u982d\u767a\u8868",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -41977,7 +45606,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proceedings International Symposium on Empirical Software Engineering (ISESE2002)",
                     "@language": "en"
                 },
@@ -42007,8 +45639,13 @@
                     "@value": "\u5b66\u8853\u8ad6\u6587\u8a8c"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "JPN",
                 "dc:title": {
@@ -42068,7 +45705,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "\u60c5\u5831\u51e6\u7406\u5b66\u4f1a\u8ad6\u6587\u8a8c"
                 },
                 "prism:volume": "41",
@@ -42094,11 +45734,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -42164,7 +45809,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proc. 24th Computer Software and Applications Conference (compsac2000)",
                     "@language": "en"
                 },
@@ -42191,11 +45839,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -42271,7 +45924,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proc. International Symposium on Future Software Technology 2000 (ISFST2000)",
                     "@language": "en"
                 },
@@ -42298,11 +45954,16 @@
                 "dc:subDepartment": "",
                 "dc:category": {
                     "@id": "2",
-                    "@value": "\u56fd\u969b\u4f1a\u8b70\u8ad6\u6587"
+                    "@value": "\u56fd\u969b\u4f1a\u8b70\u7b49\u767a\u8868"
                 },
                 "dc:authorAttr": "",
-                "dc:announcementForm": "",
+                "dc:presenters": "",
+                "dc:thesis": "",
                 "dc:reviewers": "\u67fb\u8aad\u6709\u308a",
+                "dc:announcementForm": "",
+                "dc:publicationForm": "",
+                "dc:presentation": "",
+                "dc:awards": "",
                 "dc:otherAttr": "",
                 "dc:language": "ENG",
                 "dc:title": {
@@ -42368,7 +46029,10 @@
                 "dc:publisher": {
                     "@value": ""
                 },
-                "prism:publicationName": {
+                "prism:sourceName": {
+                    "@value": ""
+                },
+                "prism:sourceName2": {
                     "@value": "Proc. International Symposium on Future Software Technology'99 (ISFST'99)",
                     "@language": "en"
                 },


### PR DESCRIPTION
2020/3/19に行われた業績管理システムの改修による下記の変更に対応:

- 業績カテゴリ名の変更
- 会議名・出版名のスキーマ変更