### PR TITLE
メンバーWidgetへのリンクをメニューに追加

### DIFF
--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -24,6 +24,11 @@
   weight = 40
 
 [[main]]
+  name = "Member"
+  url = "#people"
+  weight = 45
+
+[[main]]
   name = "Gallery"
   url = "/gallery"
   weight = 50


### PR DESCRIPTION
別ページ化はしてないけど、とりあえずメンバーがHomeページの後半に埋もれていて、アクセシビリティが良くないので、メニューにリンクを追加した。

本当は現役メンバー、過去メンバーそれぞれをページ化して、過去メンバーのページへは現役メンバーのページ内からリンク貼るようにしたい。

Closes #21