### PR TITLE
プロジェクト一覧の表示順を指定可能にした

### DIFF
--- a/content/en/project/cloud-computing/index.md
+++ b/content/en/project/cloud-computing/index.md
@@ -7,6 +7,7 @@ authors: ["kohei-ichikawa"]
 tags: ["Cloud", "SDN", "Cloud Gaming"]
 categories: []
 date: 2020-02-17T13:20:39+09:00
+weight: -70
 
 # Optional external URL for project (replaces project detail page).
 external_link: ""

--- a/content/en/project/high-performance-computing/index.md
+++ b/content/en/project/high-performance-computing/index.md
@@ -7,6 +7,7 @@ authors: ["keichi-takahashi"]
 tags: ["HPC"]
 categories: []
 date: 2020-02-18T22:13:48+09:00
+weight: -60
 
 # Optional external URL for project (replaces project detail page).
 external_link: ""

--- a/content/en/project/repository-mining/index.md
+++ b/content/en/project/repository-mining/index.md
@@ -7,6 +7,7 @@ authors: ["hajimu-iida"]
 tags: ["Repository Mining", "Software Test", "Design Pattern", "Refactoring"]
 categories: []
 date: 2020-02-17T13:14:49+09:00
+weight: -90
 
 # Optional external URL for project (replaces project detail page).
 external_link: ""

--- a/content/en/project/software-analytics/index.md
+++ b/content/en/project/software-analytics/index.md
@@ -7,6 +7,7 @@ authors: ["hajimu-iida"]
 tags: ["Software Analytics", "Code Clone", "Refactoring", "Programming Education", "Software Test"]
 categories: []
 date: 2020-02-17T13:17:13+09:00
+weight: -80
 
 # Optional external URL for project (replaces project detail page).
 external_link: ""

--- a/content/en/project/software-process/index.md
+++ b/content/en/project/software-process/index.md
@@ -7,6 +7,7 @@ authors: ["hajimu-iida"]
 tags: ["Software Process"]
 categories: []
 date: 2020-02-17T13:12:16+09:00
+weight: -100
 
 # Optional external URL for project (replaces project detail page).
 external_link: ""

--- a/content/ja/project/cloud-computing/index.md
+++ b/content/ja/project/cloud-computing/index.md
@@ -7,6 +7,7 @@ authors: ["kohei-ichikawa"]
 tags: ["Cloud", "SDN", "Cloud Gaming"]
 categories: []
 date: 2020-02-17T13:20:39+09:00
+weight: -70
 
 # Optional external URL for project (replaces project detail page).
 external_link: ""

--- a/content/ja/project/high-performance-computing/index.md
+++ b/content/ja/project/high-performance-computing/index.md
@@ -7,6 +7,7 @@ authors: ["keichi-takahashi"]
 tags: ["HPC"]
 categories: []
 date: 2020-02-18T22:13:48+09:00
+weight: -60
 
 # Optional external URL for project (replaces project detail page).
 external_link: ""

--- a/content/ja/project/repository-mining/index.md
+++ b/content/ja/project/repository-mining/index.md
@@ -7,6 +7,7 @@ authors: ["hajimu-iida"]
 tags: ["Repository Mining", "Software Test", "Design Pattern", "Refactoring"]
 categories: []
 date: 2020-02-17T13:14:49+09:00
+weight: -90
 
 # Optional external URL for project (replaces project detail page).
 external_link: ""

--- a/content/ja/project/software-analytics/index.md
+++ b/content/ja/project/software-analytics/index.md
@@ -7,6 +7,7 @@ authors: ["hajimu-iida"]
 tags: ["Software Analytics", "Code Clone", "Refactoring", "Programming Education", "Software Test"]
 categories: []
 date: 2020-02-17T13:17:13+09:00
+weight: -80
 
 # Optional external URL for project (replaces project detail page).
 external_link: ""

--- a/content/ja/project/software-process/index.md
+++ b/content/ja/project/software-process/index.md
@@ -7,6 +7,7 @@ authors: ["hajimu-iida"]
 tags: ["Software Process"]
 categories: []
 date: 2020-02-17T13:12:16+09:00
+weight: -100
 
 # Optional external URL for project (replaces project detail page).
 external_link: ""

--- a/layouts/partials/widgets/portfolio.html
+++ b/layouts/partials/widgets/portfolio.html
@@ -1,0 +1,93 @@
+{{/* Portfolio Widget */}}
+
+{{/* Initialise */}}
+{{ $ := .root }}
+{{ $st := .page }}
+{{ $items_type := $st.Params.content.page_type | default "project" }}
+{{ $columns := $st.Params.design.columns | default "2" }}
+
+{{ if ne $columns "1" }}
+{{/* Standard dual-column layout. */}}
+
+<div class="row">
+  <div class="col-12 col-lg-4 section-heading">
+
+    {{ with $st.Title }}<h1>{{ . | markdownify | emojify }}</h1>{{ end }}
+    {{ with $st.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
+
+  </div>
+  <div class="col-12 col-lg-8">
+
+{{ else }}
+{{/* Single column layout. */}}
+
+<div class="margin-auto">
+
+  <div class="center-text">
+    {{ with $st.Title }}<h1 class="mt-0">{{ . | markdownify | emojify }}</h1>{{ end }}
+    {{ with $st.Params.subtitle }}<p>{{ . | markdownify | emojify }}</p>{{ end }}
+  </div>
+  <div>
+{{ end }}
+
+    {{ with $st.Content }}{{ . }}{{ end }}
+
+    {{ if $st.Params.content.filter_button }}
+
+      {{ $filter_default := default (int $st.Params.content.filter_default) 0 }}
+
+      {{/* Parse default filter tag from front matter in the form of either tag name or CSS class name. */}}
+      {{ $default_filter_tag_raw := (index $st.Params.content.filter_button ($filter_default)).tag }}
+      {{ $default_filter_tag := printf ".js-id-%s" (replace $default_filter_tag_raw " " "-") }}
+      {{ if or (eq (substr $default_filter_tag_raw 0 1) "*") (eq (substr $default_filter_tag_raw 0 1) ".") }}
+        {{ $default_filter_tag = $default_filter_tag_raw }}
+      {{ end }}
+
+      <span class="d-none default-project-filter">{{ $default_filter_tag }}</span>
+
+      {{/* Only show filter buttons if there are multiple filters. */}}
+      {{ if gt (len $st.Params.content.filter_button) 1 }}
+      <div class="project-toolbar">
+        <div class="project-filters">
+          <div class="btn-toolbar">
+            <div class="btn-group flex-wrap">
+              {{ range $idx, $item := $st.Params.content.filter_button }}
+                {{/* Parse filter tag from front matter in the form of either tag name or CSS class name. */}}
+                {{ $data_filter := printf ".js-id-%s" (replace .tag " " "-") }}
+                {{ if or (eq (substr .tag 0 1) "*") (eq (substr .tag 0 1) ".") }}
+                  {{ $data_filter = .tag }}
+                {{ end }}
+                <a href="#" data-filter="{{ $data_filter | safeHTMLAttr }}" class="btn btn-primary btn-lg{{ if eq $idx $filter_default }} active{{ end }}">{{ .name }}</a>
+              {{ end }}
+            </div>
+          </div>
+        </div>
+      </div>
+      {{ end }}
+    {{ end }}
+
+    <div class="{{ if or $st.Params.content.filter_button (eq $st.Params.design.view 3) }}isotope projects-container{{end}} {{if eq $st.Params.design.view 3}}js-layout-masonry{{else}}row js-layout-row{{end}} {{ if eq $st.Params.design.view 5 }}project-showcase mt-5{{end}}">
+      {{ range $idx, $item := sort (where site.RegularPages "Type" $items_type) ".Params.weight"}}
+
+        {{ $link := $item.RelPermalink }}
+        {{ $target := "" }}
+        {{ if $item.Params.external_link }}
+          {{ $link = $item.Params.external_link }}
+          {{ $target = "target=\"_blank\" rel=\"noopener\"" }}
+        {{ end }}
+
+        {{ if eq $st.Params.design.view 1 }}
+          {{ partial "portfolio_li_list" (dict "item" $item) }}
+        {{ else if eq $st.Params.design.view 2 }}
+          {{ partial "portfolio_li_compact" (dict "item" $item) }}
+        {{ else if eq $st.Params.design.view 3 }}
+          {{ partial "portfolio_li_card" (dict "widget" $st "index" $idx "item" $item "link" $link "target" $target) }}
+        {{ else }}
+          {{ partial "portfolio_li_showcase" (dict "widget" $st "index" $idx "item" $item "link" $link "target" $target) }}
+        {{ end }}
+
+      {{ end }}
+    </div>
+
+  </div>
+</div>


### PR DESCRIPTION
メイントピックが上部に表示されるように、プロジェクト表示順を指定可能なようにテーマを編集した。
メイントピックにはweightで負の値を指定して、上位に来るようにしておいた。
他の詳細テーマはデフォルトの並び順（おそらく追加日時の新しい順）で表示される。