### PR TITLE
Add GSoC 2021 article

### DIFF
--- a/content/ja/post/gsoc-2021-t_sugiura/index.md
+++ b/content/ja/post/gsoc-2021-t_sugiura/index.md
@@ -29,7 +29,7 @@ projects: []
 ---
 
 M2の杉浦です。<br>
-2021年6月8日から8月17日にかけて行われた[Google Summer of Code(GSoC)](https://summerofcode.withgoogle.com/)2021に参加し，正式に修了しました．
+2021年6月8日から8月17日にかけて行われた[Google Summer of Code (GSoC)](https://summerofcode.withgoogle.com/) 2021に参加し、正式に修了しました。
 
 私はこのGSoCではKubernetesのCNIプラグインの一つとして知られている[Cilium](https://cilium.io/)の開発に参加しました。
 本プロジェクトではCiliumがもつネットワークポリシー機能へのICMPサポートの追加実装を行いました。<br>

--- a/content/ja/post/gsoc-2021-t_sugiura/index.md
+++ b/content/ja/post/gsoc-2021-t_sugiura/index.md
@@ -1,0 +1,39 @@
+---
+# Documentation: https://sourcethemes.com/academic/docs/managing-content/
+
+title: "杉浦 智基君がGoogle Summer of Code 2021に参加しました"
+subtitle: ""
+summary: ""
+authors: ["tomoki-sugiura"]
+tags: []
+categories: []
+date: 2021-09-01T10:18:14+09:00
+lastmod: 2021-09-01T10:18:14+09:00
+featured: false
+draft: false
+
+# Featured image
+# To use, add an image named `featured.jpg/png` to your page's folder.
+# Focal points: Smart, Center, TopLeft, Top, TopRight, Left, Right, BottomLeft, Bottom, BottomRight.
+image:
+  caption: ""
+  focal_point: ""
+  preview_only: false
+
+# Projects (optional).
+#   Associate this post with one or more of your projects.
+#   Simply enter your project's folder or file name without extension.
+#   E.g. `projects = ["internal-project"]` references `content/project/deep-learning/index.md`.
+#   Otherwise, set `projects = []`.
+projects: []
+---
+
+M2の杉浦です。<br>
+2021年6月8日から8月17日にかけて行われた[Google Summer of Code(GSoC)](https://summerofcode.withgoogle.com/)2021に参加し，正式に修了しました．
+
+私はこのGSoCではKubernetesのCNIプラグインの一つとして知られている[Cilium](https://cilium.io/)の開発に参加しました。
+本プロジェクトではCiliumがもつネットワークポリシー機能へのICMPサポートの追加実装を行いました。<br>
+プロジェクトの概要については[こちら](https://summerofcode.withgoogle.com/projects/#6627863052156928)，最終成果報告は[こちら](https://gist.github.com/chez-shanpu/146c7ac1ac931c742f01af8792f2ca9d)をご覧ください。
+
+また、先日行われた[RICC](https://ricc.itrc.net/)2021年度第一回研究合宿（オンライン参加）にて、本プロジェクトの内容について発表しました。
+<script async class="speakerdeck-embed" data-id="b72127216bf348e3b841109b0b09611c" data-ratio="1.33333333333333" src="//speakerdeck.com/assets/embed.js"></script>


### PR DESCRIPTION
GSoC2021に参加し修了したことについてのブログ記事を追加しました。
またGSoC期間中の開発内容をRICC合宿で発表したことにも触れ、当日の発表スライドを埋め込みました