### PR TITLE
CLOSER 2021での発表の記事のタグを修正

### DIFF
--- a/content/en/post/li-closer2021/index.md
+++ b/content/en/post/li-closer2021/index.md
@@ -5,7 +5,7 @@ title: "Mr. Guoqing Li's talk at CLOSER 2021"
 subtitle: ""
 summary: ""
 authors: ["Guoqing Li"]
-tags: ["Cloud Computing", "Virtualization Performance"]
+tags: ["Cloud", "Virtualization Performance"]
 categories: []
 date: 2021-05-12T13:33:45+09:00
 lastmod: 2021-05-12T13:33:45+09:00

--- a/content/ja/post/li-closer2021/index.md
+++ b/content/ja/post/li-closer2021/index.md
@@ -5,7 +5,7 @@ title: "Guoqing Li君の国際会議CLOSER 2021での発表"
 subtitle: ""
 summary: ""
 authors: ["Guoqing Li"]
-tags: ["Cloud Computing", "Virtualization Performance"]
+tags: ["Cloud", "Virtualization Performance"]
 categories: []
 date: 2021-05-12T13:24:47+09:00
 lastmod: 2021-05-12T13:24:47+09:00


### PR DESCRIPTION
他ページでは`Cloud Computing`ではなく`Cloud`に統一しているので．