### PR TITLE
Fix build error on Hugo 0.91+

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -76,3 +76,6 @@ ignoreFiles = ["\\.ipynb$", ".ipynb_checkpoints$", "\\.Rmd$", "\\.Rmarkdown$", "
   [[module.imports]]
     path = "github.com/wowchemy/wowchemy-hugo-modules/wowchemy/v5"
 
+[security]
+  [security.funcs]
+    getenv = ["^HUGO_", "^WC_"]


### PR DESCRIPTION
Since the Wowchemy theme reads certain environment variables, these variables need to be explicitly whitelisted on Hugo 0.91 or higher. See https://github.com/wowchemy/wowchemy-hugo-themes/discussions/2559.

Closes #121 