### PR TITLE
Remove and gitignore Hugo's lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ resources/
 public/
 jsconfig.json
 node_modules/
+.hugo_build.lock


### PR DESCRIPTION
Hugoが使用するロックファイル`.hugo_build.lock`が #126 で混入してしまったようなので，削除して`.gitignore`に追加します．