### PR TITLE
Dockerを用いた開発環境の構築手順を整備

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# ビルドステージ
+FROM golang:1.16-alpine
+
+# HUGOのバージョン指定
+ARG HUGO_VERSION=0.84.1
+
+# 必要なビルドツール
+RUN apk add --no-cache git g++ musl-dev libstdc++ ca-certificates
+
+# Hugo extended をソースからビルド
+ENV CGO_ENABLED=1
+RUN go install -tags extended github.com/gohugoio/hugo@v${HUGO_VERSION}
+
+WORKDIR /src
+EXPOSE 1313
+
+# デフォルトコマンド
+CMD ["hugo version"]

--- a/README.en.md
+++ b/README.en.md
@@ -18,6 +18,58 @@ Open `localhost:1313` in your browser to see the generated website.
 
 For more information on how to set up and create pages, please refer to the [documentation](https://wowchemy.com/docs/) of the Wowchemy theme.
 
+## Environment setup using Docker
+
+This method avoids the need to install Go or Hugo directly on your local machine and helps prevent compatibility issues between versions.
+
+### Prerequisites
+
+You need to have Docker installed. Please install [Docker Desktop](https://docs.docker.com/desktop/) (Mac/Windows) or [Docker Engine](https://docs.docker.com/engine/install/) (Linux). Additionally, for ``Linux`` users, please follow the [Post-installation steps for Linux](https://docs.docker.com/engine/install/linux-postinstall/) to run Docker commands without ``sudo``.
+
+### Steps
+
+1.  Clone this repository.
+    ```bash
+    git clone https://github.com/sdlab-naist/website
+    ```
+
+2.  Navigate into the website directory.
+    ```bash
+    cd website
+    ```
+
+3.  Start the development server. Open `http://localhost:1313` in your browser to view the generated website. On the first run, it will build the Docker image, which may take several minutes to start.
+    ```bash
+    ./docker.sh
+    ```
+
+### One-liner Command Mode
+
+By appending the arguments you want to execute as a `hugo` command after `./docker.sh`, you can run specific `hugo` commands directly within the container without starting the development server. This is useful for tasks such as creating new content files or building the site for production.
+
+The container will automatically stop and be removed after the command finishes execution.
+
+**Examples:**
+
+*   **Check Hugo version:**
+    ```bash
+    ./docker.sh hugo version
+    ```
+
+*   **Add a user (author):**
+    ```bash
+    # Add a user profile in English
+    ./docker.sh hugo new --kind authors content/en/authors/firstname-lastname
+
+    # Add a user profile in Japanese
+    ./docker.sh hugo new --kind authors content/ja/authors/firstname-lastname
+    ```
+
+*   **Add a blog post:**
+    ```bash
+    ./docker.sh hugo new --kind post content/en/post/title-of-your-blog-post
+    ```
+
 ## Workflow
 We use Github to manage the web contents in a PullRequest-driven manner.
 Before starting editing, you must create a branch, push it to the Github repository, and then issue a PullRequest.

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@
 [ドキュメント](https://wowchemy.com/docs/)を参照してください．
 
 ## Docker を使用した環境設定
-この方法では，ローカル環境に Go や Hugo を直接インストールする必要がなく，バージョン間の互換性の問題を回避できます．
+この方法では，ローカル環境にGoやHugoを直接インストールする必要がなく，バージョン間の互換性の問題を回避できます．
 
 ### 前提条件
-Docker がインストールされている必要があります．[Docker Desktop](https://docs.docker.com/desktop/) (Mac/Windows) または [Docker Engine](https://docs.docker.com/engine/install/) (Linux) をインストールしてください．さらに ``Linux`` の場合は，``sudo`` 無しで実行するために，[インストール後の手順](https://docs.docker.com/engine/install/linux-postinstall/)を実行してください．
+Docker がインストールされている必要があります．[Docker Desktop](https://docs.docker.com/desktop/)(Mac/Windows)または[Docker Engine](https://docs.docker.com/engine/install/)(Linux)をインストールしてください．さらに``Linux``の場合は，``sudo``無しで実行するために，[インストール後の手順](https://docs.docker.com/engine/install/linux-postinstall/)を実行してください．
 
 ### 作業手順
 1. 本リポジトリをクローンします．
@@ -43,16 +43,16 @@ Docker がインストールされている必要があります．[Docker Deskt
     cd website
     ```
 
-3. 開発用サーバを起動します．`http://localhost:1313` をブラウザで開くと，生成されたウェブサイトが表示されます．初回起動時はビルドが走りますので，起動まで数分かかります．
+3. 開発用サーバを起動します．`http://localhost:1313`をブラウザで開くと，生成されたウェブサイトが表示されます．初回起動時はビルドが走りますので，起動まで数分かかります．
     ```
     ./docker.sh
     ```
 
 ### ワンライナーコマンドモード
 
-`./docker.sh` の後に `hugo` コマンドとして実行したい引数を続けることで、開発サーバーを起動せずに特定の `hugo` コマンドをコンテナ内で直接実行できます。これは、新しいコンテンツファイルを作成したり、本番用のビルドを行ったりする際に便利です。
+`./docker.sh`の後に`hugo`コマンドとして実行したい引数を続けることで，開発サーバを起動せずに特定の`hugo`コマンドをコンテナで実行できます．新しいポスト作成などに利用できます．
 
-コンテナはコマンド実行後に自動的に停止・削除されます。
+コンテナはコマンド実行後に自動的に停止・削除されます．
 
 **実行例:**
 
@@ -71,7 +71,6 @@ Docker がインストールされている必要があります．[Docker Deskt
     ```
 
 *   **ブログ記事の追加:**
-    (ファイルパスは適宜変更してください)
     ```bash
     ./docker.sh hugo new --kind post content/ja/post/title-of-your-blog-post
     ```

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Docker がインストールされている必要があります．[Docker Deskt
     ./docker.sh hugo new --kind authors content/ja/authors/firstname-lastname
 
     # 英語でユーザの追加
+    ./docker.sh hugo new --kind authors content/en/authors/firstname-lastname
     ```
 
 *   **ブログ記事の追加:**

--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ Docker がインストールされている必要があります．[Docker Deskt
     # 日本語でユーザの追加
     ./docker.sh hugo new --kind authors content/ja/authors/firstname-lastname
 
-    # 英語語でユーザの追加
-    ./docker.sh hugo new --kind authors content/en/authors/firstname-lastname
+    # 英語でユーザの追加
     ```
 
 *   **ブログ記事の追加:**

--- a/README.md
+++ b/README.md
@@ -26,6 +26,56 @@
 詳細な設定方法やページの作成方法は，使用しているテーマWowchemyの
 [ドキュメント](https://wowchemy.com/docs/)を参照してください．
 
+## Docker を使用した環境設定
+この方法では，ローカル環境に Go や Hugo を直接インストールする必要がなく，バージョン間の互換性の問題を回避できます．
+
+### 前提条件
+Docker がインストールされている必要があります．[Docker Desktop](https://docs.docker.com/desktop/) (Mac/Windows) または [Docker Engine](https://docs.docker.com/engine/install/) (Linux) をインストールしてください．さらに ``Linux`` の場合は，``sudo`` 無しで実行するために，[インストール後の手順](https://docs.docker.com/engine/install/linux-postinstall/)を実行してください．
+
+### 作業手順
+1. 本リポジトリをクローンします．
+    ```
+    git clone https://github.com/sdlab-naist/website
+    ```
+
+2. websiteのディレクトリへ移動します．
+    ```
+    cd website
+    ```
+
+3. 開発用サーバを起動します．`http://localhost:1313` をブラウザで開くと，生成されたウェブサイトが表示されます．初回起動時はビルドが走りますので，起動まで数分かかります．
+    ```
+    ./docker.sh
+    ```
+
+### ワンライナーコマンドモード
+
+`./docker.sh` の後に `hugo` コマンドとして実行したい引数を続けることで、開発サーバーを起動せずに特定の `hugo` コマンドをコンテナ内で直接実行できます。これは、新しいコンテンツファイルを作成したり、本番用のビルドを行ったりする際に便利です。
+
+コンテナはコマンド実行後に自動的に停止・削除されます。
+
+**実行例:**
+
+*   **Hugo のバージョン確認:**
+    ```bash
+    ./docker.sh hugo version
+    ```
+
+*   **ユーザの追加:**
+    ```bash
+    # 日本語でユーザの追加
+    ./docker.sh hugo new --kind authors content/ja/authors/firstname-lastname
+
+    # 英語語でユーザの追加
+    ./docker.sh hugo new --kind authors content/en/authors/firstname-lastname
+    ```
+
+*   **ブログ記事の追加:**
+    (ファイルパスは適宜変更してください)
+    ```bash
+    ./docker.sh hugo new --kind post content/ja/post/title-of-your-blog-post
+    ```
+
 ## 作業フロー
 Githubを用いたPullRequest駆動でWebコンテンツを更新しています．編集作業を始める前にかならずBranchを作り，それをGithub上のレポジトリにPushした上で，PullRequestを発行する必要があります．発行したPullRequestは1人以上のレビューを受けないとmasterにマージされません．以下が典型的な作業フローの例です．
 1. masterを最新状態に更新してください．
@@ -92,7 +142,7 @@ git branch -d name-of-branch
 
 1. 下記のコマンドを実行し，記事のディレクトリを作成してください．
     ```
-    $ hugo new  --kind post content/ja/post/title-of-your-blog-post
+    $ hugo new --kind post content/ja/post/title-of-your-blog-post
     ```
     `content/ja/post/title-of-your-blog-post`というディレクトリが生成されます．
 

--- a/docker.sh
+++ b/docker.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# --- 設定 ---
+# ビルドするDockerイメージ名とタグ
+IMAGE_NAME="sdlab-naist/hugo-dev"
+IMAGE_TAG="0.84.1-go1.16"
+FULL_IMAGE_NAME="${IMAGE_NAME}:${IMAGE_TAG}"
+HOST_PORT="1313"
+CONTAINER_PORT="1313"
+DOCKERFILE="Dockerfile"
+# --- 設定ここまで ---
+
+# プロジェクトルートの取得
+PROJECT_PATH=$(dirname "$(readlink -f "$0")")
+
+# --- イメージビルド ---
+echo "開発用Dockerイメージ $FULL_IMAGE_NAME をビルドします..."
+docker build -t "$FULL_IMAGE_NAME" .
+if [ $? -ne 0 ]; then
+echo "エラー: Dockerイメージのビルドに失敗しました。"
+exit 1
+fi
+echo "イメージのビルドが完了しました。"
+# --- イメージビルドここまで ---
+
+# --- 実行モードの分岐 ---
+if [ "$#" -eq 0 ]; then
+  # --- サーバモード (引数なし) ---
+  echo "Hugo開発サーバーを起動します..."
+  echo ""
+  docker run --rm -it \
+    -p "127.0.0.1:${HOST_PORT}:${CONTAINER_PORT}" \
+    -v "${PROJECT_PATH}:/src" \
+    -w "/src" \
+    -u "$(id -u):$(id -g)" \
+    "${FULL_IMAGE_NAME}" \
+    hugo server --bind="0.0.0.0" --baseURL="http://localhost:${HOST_PORT}/" -DF
+else
+  # --- ワンライナーコマンドモード (引数あり) ---
+  echo "引数 \"$@\" をコンテナ内で hugo コマンドとして実行します..."
+  echo ""
+
+  docker run --rm -it \
+    -v "${PROJECT_PATH}:/src" \
+    -w "/src" \
+    -u "$(id -u):$(id -g)" \
+    "${FULL_IMAGE_NAME}" \
+    "$@" # スクリプトに渡された引数をそのままhugoの引数として渡して実行
+fi
+
+exit 0


### PR DESCRIPTION
Dockerを用いた開発環境の構築手順を追加・整備しました．
本手法によって，ローカル環境にGoやHugoを直接インストールする手間を省き，バージョン互換性の問題を回避します．

主な変更点:
- docker.sh 追加
  -  Dockerイメージのビルドとコンテナ実行をラップ
  - 引数なしで開発サーバを起動
  - 引数ありで任意の hugo コマンドを実行
- README.md 更新
  -  Docker を利用した環境設定手順を追記
  - 引数なしで開発サーバを起動
  - docker.sh の使い方（サーバモード、ワンライナーモード）を記載