### PR TITLE
Refine shota-sawada profile content

### DIFF
--- a/content/en/authors/shota-sawada/_index.md
+++ b/content/en/authors/shota-sawada/_index.md
@@ -10,11 +10,11 @@ authors:
 superuser: false
 
 # Role/position (e.g., Professor of Artificial Intelligence)
-role: "Summer 2025 Intern"
+role: Summer 2025 Intern
 
 # Organizations/Affiliations
 organizations:
-- name: ""
+- name:
   url: ""
 
 # Short bio (displayed in user profile at end of posts)
@@ -22,15 +22,17 @@ bio:
 
 # List each interest with a dash
 interests:
--
+- Video games
+- Driving
+- Karaoke
 
 education:
   courses:
-  - course: Department of Systems Engineering, Information Systems Course
-    institution: National Institute of Technology, Nara College (Advanced Course)
+  - course: Systems Innovation Engineering
+    institution: NIT, Nara College
     year: 2025-
-  - course: Department of Information Engineering
-    institution: National Institute of Technology, Nara College
+  - course: Information Engineering
+    institution: NIT, Nara College
     year: 2020-2025
 
 # Social/Academic Networking

--- a/content/ja/authors/shota-sawada/_index.md
+++ b/content/ja/authors/shota-sawada/_index.md
@@ -22,7 +22,9 @@ bio:
 
 # List each interest with a dash
 interests:
-- 
+- ゲーム
+- ドライブ
+- カラオケ
 
 education:
   courses:

--- a/content/ja/authors/shota-sawada/_index.md
+++ b/content/ja/authors/shota-sawada/_index.md
@@ -27,13 +27,13 @@ interests:
 - カラオケ
 
 education:
-  courses:
-  - course: システム創成工学専攻 情報システムコース
-    institution: 奈良工業高等専門学校 専攻科
-    year: 2025-
-  - course: 情報工学科
-    institution: 奈良工業高等専門学校
-    year: 2020-2025
+  courses:
+  - course: システム創成工学専攻 情報システムコース
+    institution: 奈良工業高等専門学校 専攻科
+    year: 2025-
+  - course: 情報工学科
+    institution: 奈良工業高等専門学校
+    year: 2020-2025
 
 # Social/Academic Networking
 # For available icons, see: https://sourcethemes.com/academic/docs/page-builder/#icons


### PR DESCRIPTION
## Summary
- ja: fill in interests (ゲーム / ドライブ / カラオケ)
- en: match interests with ja (Video games / Driving / Karaoke)
- en: align education wording with kosei-horikawa (Systems Innovation Engineering / Information Engineering / NIT, Nara College)

Follow-up to #290 — that PR was merged before these refinements landed.

## Test plan
- [x] /ja/authors/shota-sawada/ shows interests と education
- [x] /en/authors/shota-sawada/ shows matching interests and concise education wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)