### PR TITLE
Update Yutaro Kashiwa profile (2026年8月)

### DIFF
--- a/content/en/authors/yutaro-kashiwa/_index.md
+++ b/content/en/authors/yutaro-kashiwa/_index.md
@@ -255,6 +255,20 @@ weight: 20
 .grant-detail.active {
   display: block;
 }
+.pub-pdf {
+  display: inline-block;
+  margin-top: 0.3rem;
+  background: #e3f2fd;
+  color: #1565c0;
+  padding: 0.1rem 0.45rem;
+  border-radius: 3px;
+  font-size: 0.8rem;
+  text-decoration: none;
+  transition: background 0.2s;
+}
+.pub-pdf:hover {
+  background: #bbdefb;
+}
 </style>
 
 <div class="section-block">
@@ -301,6 +315,7 @@ Conference rankings are based on <a href="https://portal.core.edu.au/conf-ranks/
   <div class="grant-detail">
     T Shirai, O Nourry, Y Kashiwa, K Fujiwara, Y Kamei, H Iida<br>
     IEEE Transactions on Software Engineering, 2026.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TSE26_Shirai.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -312,6 +327,7 @@ Conference rankings are based on <a href="https://portal.core.edu.au/conf-ranks/
   <div class="grant-detail">
     W Chatlatanagulchai, H Li, Y Kashiwa, B Reid, K Thonglek, P Leelaprute, A Rungsawang, B Manaskasemsak, B Adams, A E Hassan, H Iida<br>
     ACM Transactions on Software Engineering and Methodology, 2026.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Worrawalan.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -323,6 +339,7 @@ Conference rankings are based on <a href="https://portal.core.edu.au/conf-ranks/
   <div class="grant-detail">
     M Watanabe, H Li, Y Kashiwa, B Reid, H Iida, A E Hassan<br>
     ACM Transactions on Software Engineering and Methodology, 2026.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Watanabe.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -334,6 +351,7 @@ Conference rankings are based on <a href="https://portal.core.edu.au/conf-ranks/
   <div class="grant-detail">
     I Nakamura, Y Kashiwa, B Lin, H Iida<br>
     ACM Transactions on Software Engineering and Methodology, 2026.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Nakamura.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -345,6 +363,7 @@ Conference rankings are based on <a href="https://portal.core.edu.au/conf-ranks/
   <div class="grant-detail">
     S Yoshimoto, K Horikawa, D Feitosa, Y Kashiwa, H Iida<br>
     ESEM 2026.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ESEM2026_Yoshimoto.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -356,6 +375,7 @@ Conference rankings are based on <a href="https://portal.core.edu.au/conf-ranks/
   <div class="grant-detail">
     A Shirakawa, T Shirai, Y Kashiwa, M Kondo, Y Kamei, H Iida<br>
     ESEM 2026.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ESEM2026_Shirakawa.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -367,6 +387,7 @@ Conference rankings are based on <a href="https://portal.core.edu.au/conf-ranks/
   <div class="grant-detail">
     R Opdebeeck, M Alfadel, A Rahman, Y Kashiwa, J F Ferreira, R G Kula, C De Roover<br>
     MSR 2026.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Opdebeeck.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -378,6 +399,7 @@ Conference rankings are based on <a href="https://portal.core.edu.au/conf-ranks/
   <div class="grant-detail">
     T Shirai, O Nourry, Y Kashiwa, K Fujiwara, H Iida<br>
     MSR 2026.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Shirai.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -389,6 +411,7 @@ Conference rankings are based on <a href="https://portal.core.edu.au/conf-ranks/
   <div class="grant-detail">
     O Nourry, Y Kashiwa, W Shang, H Shu, Y Kamei<br>
     ACM Transactions on Software Engineering and Methodology, 2024.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2024_Nourry.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -400,6 +423,7 @@ Conference rankings are based on <a href="https://portal.core.edu.au/conf-ranks/
   <div class="grant-detail">
     M Yin, Y Kashiwa, K Gallaba, M Alfadel, Y Kamei, S McIntosh<br>
     ASE 2024.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ASE2024_Yin.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -411,6 +435,7 @@ Conference rankings are based on <a href="https://portal.core.edu.au/conf-ranks/
   <div class="grant-detail">
     H Kuramoto, D Wang, M Kondo, Y Kashiwa, Y Kamei, N Ubayashi<br>
     Empirical Software Engineering, 2024.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EMSE2024_Kuramoto.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -422,6 +447,7 @@ Conference rankings are based on <a href="https://portal.core.edu.au/conf-ranks/
   <div class="grant-detail">
     O Nourry, Y Kashiwa, B Lin, G Bavota, M Lanza, Y Kamei<br>
     ACM Transactions on Software Engineering and Methodology, 2023.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2023_Nourry.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -433,6 +459,7 @@ Conference rankings are based on <a href="https://portal.core.edu.au/conf-ranks/
   <div class="grant-detail">
     Y Kashiwa, R Nishikawa, Y Kamei, M Kondo, E Shihab, R Sato, N Ubayashi<br>
     Information and Software Technology, 2022.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/IST2022_Kashiwa.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -444,6 +471,7 @@ Conference rankings are based on <a href="https://portal.core.edu.au/conf-ranks/
   <div class="grant-detail">
     M Kondo, Y Kashiwa, Y Kamei, O Mizuno<br>
     Empirical Software Engineering, 2022.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EMSE2022_Kondo.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -455,6 +483,7 @@ Conference rankings are based on <a href="https://portal.core.edu.au/conf-ranks/
   <div class="grant-detail">
     Y Kashiwa, K Shimizu, B Lin, G Bavota, M Lanza, Y Kamei, N Ubayashi<br>
     ICSME 2021.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2021_Kashiwa.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -466,6 +495,7 @@ Conference rankings are based on <a href="https://portal.core.edu.au/conf-ranks/
   <div class="grant-detail">
     O Nourry, Y Kashiwa, Y Kamei, N Ubayashi<br>
     Information and Software Technology, 2021.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/IST2021_Nourry.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -560,7 +590,7 @@ Other publications: <https://github.com/Yutaro-Kashiwa/papers>
 
 <div class="grant-item">
   <div class="grant-header" onclick="toggleGrant(this)">
-    <span class="grant-title">2026-2029: JSPS KAKENHI (B) (PI: Akinori Ihara)</span>
+    <span class="grant-title">2026-2029: JSPS KAKENHI (B) (PI: Masao Ohira)</span>
   </div>
   <div class="grant-detail">
     Project: "Understanding and Preventing Model Collapse of Generative AI in System Development"<br>
@@ -678,10 +708,10 @@ Other publications: <https://github.com/Yutaro-Kashiwa/papers>
     <span class="project-desc">Empirical analysis and quality improvement of autonomous software development by AI agents</span>
   </div>
   <div class="project-papers">
-    <span class="project-topic"><span class="project-topic-name">Context Files</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Worrawalan.pdf">TOSEM</a></span>
-    <span class="project-topic"><span class="project-topic-name">Pull Requests</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Watanabe.pdf">TOSEM</a></span>
-    <span class="project-topic"><span class="project-topic-name">Code Quality</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Horikawa.pdf">MSR</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Watanabe.pdf">MSR</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EASE2026_Sawada.pdf">EASE</a></span>
-    <span class="project-topic"><span class="project-topic-name">Test Generation</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Yoshimoto.pdf">MSR</a></span>
+    <span class="project-topic"><span class="project-topic-name">Context Files</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Worrawalan.pdf" target="_blank" rel="noopener">📄 TOSEM</a></span>
+    <span class="project-topic"><span class="project-topic-name">Pull Requests</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Watanabe.pdf" target="_blank" rel="noopener">📄 TOSEM</a></span>
+    <span class="project-topic"><span class="project-topic-name">Code Quality</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Horikawa.pdf" target="_blank" rel="noopener">📄 MSR</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Watanabe.pdf" target="_blank" rel="noopener">📄 MSR</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EASE2026_Sawada.pdf" target="_blank" rel="noopener">📄 EASE</a></span>
+    <span class="project-topic"><span class="project-topic-name">Test Generation</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Yoshimoto.pdf" target="_blank" rel="noopener">📄 MSR</a></span>
   </div>
 </div>
 
@@ -691,10 +721,10 @@ Other publications: <https://github.com/Yutaro-Kashiwa/papers>
     <span class="project-desc">Development support using ML/LLM (defect prediction, code completion, review automation)</span>
   </div>
   <div class="project-papers">
-    <span class="project-topic"><span class="project-topic-name">JIT Defect Prediction</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2024_Morita.pdf">SANER</a></span>
-    <span class="project-topic"><span class="project-topic-name">Code Completion</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2023_Fukumoto.pdf">SANER</a></span>
-    <span class="project-topic"><span class="project-topic-name">Code Review</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2024_Morikawa.pdf">ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EASE2024_Watanabe.pdf">EASE</a></span>
-    <span class="project-topic"><span class="project-topic-name">Bug Triage</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/IEICE2020_Kashiwa.pdf">IEICE</a></span>
+    <span class="project-topic"><span class="project-topic-name">JIT Defect Prediction</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2024_Morita.pdf" target="_blank" rel="noopener">📄 SANER</a></span>
+    <span class="project-topic"><span class="project-topic-name">Code Completion</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2023_Fukumoto.pdf" target="_blank" rel="noopener">📄 SANER</a></span>
+    <span class="project-topic"><span class="project-topic-name">Code Review</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2024_Morikawa.pdf" target="_blank" rel="noopener">📄 ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EASE2024_Watanabe.pdf" target="_blank" rel="noopener">📄 EASE</a></span>
+    <span class="project-topic"><span class="project-topic-name">Bug Triage</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/IEICE2020_Kashiwa.pdf" target="_blank" rel="noopener">📄 IEICE</a></span>
   </div>
 </div>
 
@@ -704,11 +734,11 @@ Other publications: <https://github.com/Yutaro-Kashiwa/papers>
     <span class="project-desc">CI/CD pipeline optimization, fuzzing, and test automation research</span>
   </div>
   <div class="project-papers">
-    <span class="project-topic"><span class="project-topic-name">Build Acceleration</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ASE2024_Yin.pdf">ASE</a></span>
-    <span class="project-topic"><span class="project-topic-name">Continuous Fuzzing</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TSE2026_Shirai.pdf">TSE</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2023_Nourry.pdf">TOSEM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2024_Nourry.pdf">TOSEM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Shirai.pdf">MSR</a></span>
-    <span class="project-topic"><span class="project-topic-name">Test Maintenance</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2023_Fujita.pdf">ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2021_Kashiwa.pdf">ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ESEM2026_Shirakawa.pdf">ESEM</a></span>
-    <span class="project-topic"><span class="project-topic-name">Cloud & Container</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/APSEC2023_Suwanachote.pdf">APSEC</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SCAM2024_Mabuchi.pdf">SCAM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2022_Higashi.pdf">SANER</a></span>
-    <span class="project-topic"><span class="project-topic-name">Dependency & Config</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2025_Suwanachote.pdf">MSR</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Opdebeeck.pdf">MSR</a></span>
+    <span class="project-topic"><span class="project-topic-name">Build Acceleration</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ASE2024_Yin.pdf" target="_blank" rel="noopener">📄 ASE</a></span>
+    <span class="project-topic"><span class="project-topic-name">Continuous Fuzzing</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TSE26_Shirai.pdf" target="_blank" rel="noopener">📄 TSE</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2023_Nourry.pdf" target="_blank" rel="noopener">📄 TOSEM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2024_Nourry.pdf" target="_blank" rel="noopener">📄 TOSEM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Shirai.pdf" target="_blank" rel="noopener">📄 MSR</a></span>
+    <span class="project-topic"><span class="project-topic-name">Test Maintenance</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2023_Fujita.pdf" target="_blank" rel="noopener">📄 ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2021_Kashiwa.pdf" target="_blank" rel="noopener">📄 ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ESEM2026_Shirakawa.pdf" target="_blank" rel="noopener">📄 ESEM</a></span>
+    <span class="project-topic"><span class="project-topic-name">Cloud & Container</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/APSEC2023_Suwanachote.pdf" target="_blank" rel="noopener">📄 APSEC</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SCAM2024_Mabuchi.pdf" target="_blank" rel="noopener">📄 SCAM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2022_Higashi.pdf" target="_blank" rel="noopener">📄 SANER</a></span>
+    <span class="project-topic"><span class="project-topic-name">Dependency & Config</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2025_Suwanachote.pdf" target="_blank" rel="noopener">📄 MSR</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Opdebeeck.pdf" target="_blank" rel="noopener">📄 MSR</a></span>
   </div>
 </div>
 
@@ -718,8 +748,8 @@ Other publications: <https://github.com/Yutaro-Kashiwa/papers>
     <span class="project-desc">Detection and management of technical debt, and analysis of refactoring impact on tests</span>
   </div>
   <div class="project-papers">
-    <span class="project-topic"><span class="project-topic-name">Refactoring</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/IST2021_Nourry.pdf">IST</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2022_Nourry.pdf">ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SCAM2021_Atwi.pdf">SCAM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2026_Liu.pdf">SANER</a></span>
-    <span class="project-topic"><span class="project-topic-name">SATD</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/IST2022_Kashiwa.pdf">IST</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Nakamura.pdf">TOSEM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ESEM2026_Yoshimoto.pdf">ESEM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICPC2025_Yonekura.pdf">ICPC</a></span>
+    <span class="project-topic"><span class="project-topic-name">Refactoring</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/IST2021_Nourry.pdf" target="_blank" rel="noopener">📄 IST</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2022_Nourry.pdf" target="_blank" rel="noopener">📄 ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SCAM2021_Atwi.pdf" target="_blank" rel="noopener">📄 SCAM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2026_Liu.pdf" target="_blank" rel="noopener">📄 SANER</a></span>
+    <span class="project-topic"><span class="project-topic-name">SATD</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/IST2022_Kashiwa.pdf" target="_blank" rel="noopener">📄 IST</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Nakamura.pdf" target="_blank" rel="noopener">📄 TOSEM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ESEM2026_Yoshimoto.pdf" target="_blank" rel="noopener">📄 ESEM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICPC2025_Yonekura.pdf" target="_blank" rel="noopener">📄 ICPC</a></span>
   </div>
 </div>
 
@@ -729,9 +759,9 @@ Other publications: <https://github.com/Yutaro-Kashiwa/papers>
     <span class="project-desc">Analysis of bug reports, prediction of high-impact bugs, and issue-commit linking</span>
   </div>
   <div class="project-papers">
-    <span class="project-topic"><span class="project-topic-name">Visual Issues</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EMSE2024_Kuramoto.pdf">EMSE</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICPC2022_Kuramoto.pdf">ICPC</a></span>
-    <span class="project-topic"><span class="project-topic-name">High Impact Bugs</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2014_Kashiwa.pdf">ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2015_Ohira.pdf">MSR</a></span>
-    <span class="project-topic"><span class="project-topic-name">Issue Linking</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EMSE2022_Kondo.pdf">EMSE</a></span>
+    <span class="project-topic"><span class="project-topic-name">Visual Issues</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EMSE2024_Kuramoto.pdf" target="_blank" rel="noopener">📄 EMSE</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICPC2022_Kuramoto.pdf" target="_blank" rel="noopener">📄 ICPC</a></span>
+    <span class="project-topic"><span class="project-topic-name">High Impact Bugs</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2014_Kashiwa.pdf" target="_blank" rel="noopener">📄 ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2015_Ohira.pdf" target="_blank" rel="noopener">📄 MSR</a></span>
+    <span class="project-topic"><span class="project-topic-name">Issue Linking</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EMSE2022_Kondo.pdf" target="_blank" rel="noopener">📄 EMSE</a></span>
   </div>
 </div>
 

--- a/content/en/authors/yutaro-kashiwa/_index.md
+++ b/content/en/authors/yutaro-kashiwa/_index.md
@@ -20,7 +20,7 @@ organizations:
     url: "https://itcw3.naist.jp/index.en.html"
 
 # Short bio (displayed in user profile at end of posts)
-bio: Yutaro Kashiwa is an assistant professor at Nara Institute of Science and Technology (NAIST), Japan.  He worked for Hitachi Ltd. as a full-time software engineer for two years before spending three years as a research fellow of the Japan Society for the Promotion of Science. He received his Ph.D. degree in engineering from Wakayama University in 2020. After receiving his Ph.D., he was a post-doc under SENSOR (SENsible SOftware Refactoring) project led by Yasutaka Kamei and Gabriele Bavota. His research interests include empirical software engineering, specifically the analysis of software bugs, testing, refactoring, and release.
+bio: Yutaro Kashiwa is an associate professor at Nara Institute of Science and Technology (NAIST), Japan, and a JST FOREST Researcher. He worked for Hitachi Ltd. as a full-time software engineer for two years before spending three years as a research fellow of the Japan Society for the Promotion of Science. He received his Ph.D. degree in engineering from Wakayama University in 2020. His research interests include empirical software engineering, specifically the analysis of software bugs, testing, refactoring, and release.
 
 # Social/Academic Networking
 # For available icons, see: https://wowchemy.com/docs/page-builder/#icons
@@ -59,178 +59,711 @@ user_groups:
 weight: 20
 ---
 
-## Profile
+<style>
+/* Section blocks */
+.section-block {
+  background: #f8f9fa;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+.section-block h3 {
+  background: #1565c0;
+  color: #fff;
+  padding: 0.6rem 1rem;
+  margin: -1.5rem -1.5rem 1rem -1.5rem;
+  border-radius: 8px 8px 0 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+/* Tabs */
+.tab-container {
+  margin-top: 0.5rem;
+}
+.tab-buttons {
+  display: inline-flex;
+  background: #e8e8e8;
+  border-radius: 6px;
+  padding: 3px;
+  margin-bottom: 1rem;
+}
+.tab-btn {
+  padding: 0.5rem 1.2rem;
+  cursor: pointer;
+  border: none;
+  background: transparent;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #666;
+  border-radius: 4px;
+  transition: all 0.2s;
+}
+.tab-btn:hover {
+  color: #333;
+}
+.tab-btn.active {
+  background: #fff;
+  color: #1565c0;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+.tab-pane {
+  display: none;
+}
+.tab-pane.active {
+  display: block;
+}
+/* Accordion items */
+.grant-item {
+  margin-bottom: 0;
+  padding: 0.15rem 0;
+}
+.grant-header {
+  display: flex;
+  align-items: flex-start;
+  cursor: pointer;
+  padding: 0.1rem 0;
+}
+.grant-header::before {
+  content: '▶';
+  font-size: 0.65rem;
+  margin-right: 0.5rem;
+  margin-top: 0.3rem;
+  transition: transform 0.2s;
+  color: #1565c0;
+}
+.grant-header.active::before {
+  transform: rotate(90deg);
+}
+.grant-title {
+  font-weight: 600;
+  flex: 1;
+  color: #333;
+}
+.pub-venue {
+  margin-left: 0.5rem;
+  font-size: 0.8rem;
+  color: #fff;
+  background: #1565c0;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+/* Career list */
+.career-list > div {
+  padding: 0.15rem 0;
+  line-height: 1.5;
+}
+.sub-item {
+  padding-left: 1.5rem;
+  color: #555;
+  font-size: 0.95rem;
+}
+/* Award & Qualification lists */
+.award-list > div:not(.group-label), .qual-list > div {
+  padding: 0.2rem 0 0.2rem 0;
+  line-height: 1.4;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.award-list > div:not(.group-label)::before {
+  content: '🏆';
+  font-size: 0.75rem;
+  flex-shrink: 0;
+}
+.qual-list > div::before {
+  content: '✓';
+  font-size: 0.85rem;
+  font-weight: bold;
+  color: #1565c0;
+  flex-shrink: 0;
+}
+/* Group labels */
+.group-label {
+  font-weight: 600;
+  color: #1565c0;
+  margin-top: 0.8rem;
+  margin-bottom: 0.2rem;
+  padding-bottom: 0.2rem;
+  border-bottom: 1px solid #e0e0e0;
+}
+.group-label:first-child {
+  margin-top: 0;
+}
+/* Research projects */
+.project-area {
+  margin-bottom: 0.8rem;
+  padding-left: 1rem;
+  border-left: 3px solid #1565c0;
+}
+.project-title {
+  margin-bottom: 0.2rem;
+}
+.project-title b {
+  font-size: 1rem;
+  display: block;
+}
+.project-desc {
+  font-size: 0.85rem;
+  color: #666;
+}
+.project-papers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin-top: 0.3rem;
+}
+.project-topic {
+  display: inline-flex;
+  align-items: center;
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.8rem;
+}
+.project-topic-name {
+  color: #333;
+  margin-right: 0.4rem;
+}
+.project-topic a {
+  background: #e3f2fd;
+  color: #1565c0;
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+  font-size: 0.75rem;
+  margin-left: 0.15rem;
+  text-decoration: none;
+  transition: background 0.2s;
+}
+.project-topic a:hover {
+  background: #bbdefb;
+}
+.grant-detail {
+  display: none;
+  padding-left: 1.2rem;
+  margin-top: 0.2rem;
+  margin-bottom: 0.2rem;
+  color: #555;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  background: #f8f8f8;
+  padding: 0.4rem 0.8rem;
+  border-radius: 4px;
+}
+.grant-detail.active {
+  display: block;
+}
+</style>
 
-<p>I am an assistant professor at Nara Institute of Science and Technology (NAIST), Japan.  I worked for Hitachi Ltd. as a full-time software engineer for two years before spending three years as a research fellow of the Japan Society for the Promotion of Science. I received my Ph.D. degree in engineering from Wakayama University in 2020. After this, I was a post-doc under SENSOR (SENsible SOftware Refactoring) project led by Yasutaka Kamei and Gabriele Bavota. </p>
+<div class="section-block">
+<h3>Profile</h3>
 
-<p>My research interests include empirical software engineering, specifically the analysis of software bugs, testing, refactoring, and release. In recent years, I have focused on utilizing trace logs generated during test exercises using dynamic analysis. These generated traces can improve Just-in-time bug predictions and automatic refactoring tools. Also, many of my projects involve foreign researchers from Canada, Switzerland, Netherlands, luxembourg, and Thailand. </p>
-<br>
+I am an associate professor at Nara Institute of Science and Technology (NAIST), Japan, and a JST FOREST Researcher. I worked for Hitachi Ltd. as a full-time software engineer for two years before spending three years as a research fellow of the Japan Society for the Promotion of Science. I received my Ph.D. degree in engineering from Wakayama University in 2020. After this, I was a post-doc under SENSOR (SENsible SOftware Refactoring) project led by Yasutaka Kamei and Gabriele Bavota.
 
-## Biography
+My research interests include empirical software engineering, specifically mining software repositories. I focus on utilizing data generated from continuous integration and DevOps to improve software quality and development efficiency. In recent years, I have been actively working on Just-In-Time defect prediction and automatic refactoring using trace logs obtained through dynamic analysis during test execution. I also collaborate with many researchers from universities in Canada, Switzerland, the Netherlands, Luxembourg, and Thailand on numerous international joint research projects. Ph.D. in Engineering.
 
-<div>
-    <div><b>
-        <span class="col-1">Apr. 2015--Mar. 2017: </span>
-        <span class="col-2">Full-time software developer at Hitachi, Ltd.</span>
-    </b></div>
-    <div><b>
-        <span class="col-1">Apr. 2017--Mar. 2020:</span>
-        <span class="col-2">Doctoral student at Wakayama University</span>
-    </b></div>
-    <div><b>
-        <span class="col-1">Apr. 2017--Mar. 2020:</span>
-        <span class="col-2">JSPS Research Fellowships for Young Scientists (DC1)</span>
-    </b></div>
-    <div>
-        <span class="col-1">　Apr. 2019--Sep. 2019: </span>
-        <span class="col-2">Visiting researcher at Polytechnique Montréal</span>
-    </div>
-    <div><b>
-        <span class="col-1">Apr. 2020--Mar. 2022: </span>
-        <span class="col-2">Reseach assistant researcher at Kyushu University</span>
-<!--         Graduate School and Faculty of Information Science and Electrical Engineering,  -->
-    </b></div>
-    <div>
-        <span class="col-1">　Nov. 2021--Feb. 2022:</span>
-        <span class="col-2">Visiting researcher at Università della Svizzera Italiana</span>
-    </div>
-    <div><b>
-        <span class="col-1">Apr. 2022--Mar. 2025: &ensp;&ensp;</span>
-        <span class="col-2">Assistant professor at Nara Institute of Science and Technology</span>
-    </b></div>
-    <div><b>
-        <span class="col-1">Oct. 2022---present: &ensp;&ensp;</span>
-        <span class="col-2">Japan Science and Technology Agency PRESTO-Researcher</span>
-    </b></div>
-   <div>
-        <span class="col-1">　Oct. 2022---Nov. 2022: </span>
-        <span class="col-2">Visiting researcher at Radboud University</span>
-    </div>
-       <div>
-        <span class="col-1">　Sep. 2023---Oct. 2023: </span>
-        <span class="col-2">Visiting researcher at Radboud University</span>
-    </div>
-    <div><b>
-        <span class="col-1">Apr. 2025--Present: &ensp;&ensp;</span>
-        <span class="col-2">Associate professor at Nara Institute of Science and Technology</span>
-    </b></div>
 </div>
 
-<br>
+<div class="section-block">
+<h3>Biography</h3>
 
-## Recent Major Publications
+<div class="career-list">
+  <div><b>Apr. 2015 - Mar. 2017:</b> Full-time Software Developer at Hitachi, Ltd.</div>
+  <div><b>Apr. 2017 - Mar. 2020:</b> Doctoral Student at Wakayama University</div>
+  <div><b>Apr. 2017 - Mar. 2020:</b> JSPS Research Fellow (DC1)</div>
+  <div class="sub-item">Apr. 2019 - Sep. 2019: Visiting Researcher at Polytechnique Montréal</div>
+  <div><b>Apr. 2020 - Mar. 2022:</b> Research Assistant Professor at Kyushu University</div>
+  <div class="sub-item">Nov. 2021 - Feb. 2022: Visiting Researcher at Università della Svizzera italiana</div>
+  <div><b>Apr. 2022 - Mar. 2025:</b> Assistant Professor at Nara Institute of Science and Technology</div>
+  <div><b>Oct. 2022 - Mar. 2026:</b> JST PRESTO Researcher (concurrent)</div>
+  <div class="sub-item">Oct. 2022 - Nov. 2022: Visiting Researcher at Radboud University</div>
+  <div class="sub-item">Sep. 2023 - Oct. 2023: Visiting Researcher at Radboud University</div>
+  <div><b>Apr. 2025 - Present:</b> Associate Professor at Nara Institute of Science and Technology</div>
+  <div><b>Aug. 2026 - Present:</b> JST FOREST Researcher (concurrent)</div>
+</div>
 
-- <b>Leveraging Context Information for Self-Admitted Technical Debt Detection</b><br>
-  M Yonekura, Y Kashiwa, B Lin, K Fujiwara, H Iida<br>
-  The 33rd IEEE/ACM International Conference on Program Comprehension (ICPC'25), 2025.
-- <b>My Fuzzers Won’t Build: An Empirical Study of Fuzzing Build Failures</b><br>
-  O Nourry, Y Kashiwa, W Shang, H Shu, Y Kamei<br>
-  ACM Transactions on Software Engineering and Methodology (TOSEM), 2024.
-- <b>Developer-Applied Accelerations in Continuous Integration</b><br>
-  M Yin, Y Kashiwa, K Gallaba, M Alfadel, Y Kamei, S McIntosh<br>
-  The 39th IEEE/ACM International Conference on Automated Software Engineering (ASE'24), 2024.
-- <b>Understanding the Characteristics and the Role of Visual Issue Reports</b><br>
-  H Kuramoto, D Wang, M Kondo, Y Kashiwa, Y Kamei, N Ubayashi<br>
-  Empirical Software Engineering, 2024.
-- <b>TraceJIT: Evaluating the Impact of Behavioral Code Change on Just-In-Time Defect Prediction</b><br>
-  I Morita, Y Kashiwa, M Kondo, J Sohn, S Macintosh, Y Kamei, and N Ubayashi<br>
-  The 31th IEEE International Conference on Software Analysis, Evolution and Reengineering (SANER), 2024.
-- <b>The Human Side of Fuzzing: Challenges Faced by Developers During Fuzzing Activities</b><br>
-  O Nourry, Y Kashiwa, B Lin, G Bavota, M Lanza, and Y Kamei<br>
-  ACM Transactions on Software Engineering and Methodology (TOSEM), 2023.
-- <b>An Empirical Study on Self-admitted Technical Debt in Modern Code Review</b><br>
-  Y Kashiwa, R Nishikawa, Y Kamei, M Kondo, E Shihab, R Sato, N Ubayashi<br>
-  Information and Software Technology (IST), 2022.
-- <b>An Empirical Study of Issue-Link Algorithms: Which Issue-Link Algorithms Should We Use?</b><br>
-  M Kondo, Y Kashiwa, Y Kamei, O Mizuno<br>
-  Empirical Software Engineering, 2022.
-- <b>Does Refactoring Break Tests and to What Extent?</b><br>
-  Y Kashiwa, K Shimizu, B Lin, G Bavota, M Lanza, Y Kamei, N Ubayashi<br>
-  37th International Conference on Software Maintenance and Evolution (ICSME2021), 2021.
-- <b>Does Shortening the Release Cycle Affect Refactoring Activities: A Case Study of the JDT Core, Platform SWT, and UI projects</b><br>
-  O Nourry, Y Kashiwa, Y Kamei, N Ubayashi<br>
-  Information and Software Technology (IST), 2021.
+</div>
 
-Other publications can be found here. <br>
-<https://scholar.google.com/citations?user=hFD-GC8AAAAJ&hl=en>
-<br>
-<br>
+<div class="section-block">
+<h3>Selected Publications</h3>
 
-## Awards
+<p style="font-size:0.85rem; color:#666; margin-bottom:1rem;">
+Conference rankings are based on <a href="https://portal.core.edu.au/conf-ranks/" target="_blank">CORE Rankings</a>. Journal rankings are based on <a href="https://www.scimagojr.com/" target="_blank">SCImago Journal Rankings (SJR)</a>.
+</p>
 
-#### To Myself or My publications
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">Large-Scale Empirical Analysis of Continuous Fuzzing</span>
+    <span class="pub-venue">TSE [Q1]</span>
+  </div>
+  <div class="grant-detail">
+    T Shirai, O Nourry, Y Kashiwa, K Fujiwara, Y Kamei, H Iida<br>
+    IEEE Transactions on Software Engineering, 2026.
+  </div>
+</div>
 
-- Research Encouragement Award, IEICE Special Interest Groups on Software Science, 2023.
-- IEEE CS Kansai Chapter Young Author Award 2022.
-- Research Encouragement Award, IEICE Special Interest Groups on Software Science, 2022.
-- Specially Selected Paper Award, Transactions of Information Processing Society of Japan, 2021.
-- IPSJ Outstanding Paper Award, Transactions of Information Processing Society of Japan, 2016.
-- IPSJ Yamashita SIG Research Award, 2016.
-- Research Encouragement Award, Software Symposium in Wakayama, 2015.
-- President's Award in Wakayama University, 2015.
-- Student Research Award, SIGSE Special Interest Groups on Software Engineering, 2015.
-- Specially Selected Paper Award, Transactions of Information Processing Society of Japan, 2015.
-- Best Paper Award, Software Engineering Symposium 2014, 2014.
-- Interactive Award, Software Engineering Symposium 2013, 2013.
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">Agent READMEs: An Empirical Study of Context Files for Agentic Coding</span>
+    <span class="pub-venue">TOSEM [Q1]</span>
+  </div>
+  <div class="grant-detail">
+    W Chatlatanagulchai, H Li, Y Kashiwa, B Reid, K Thonglek, P Leelaprute, A Rungsawang, B Manaskasemsak, B Adams, A E Hassan, H Iida<br>
+    ACM Transactions on Software Engineering and Methodology, 2026.
+  </div>
+</div>
 
-#### To Students
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">On the Use of Agentic Coding: An Empirical Study of Pull Requests on GitHub</span>
+    <span class="pub-venue">TOSEM [Q1]</span>
+  </div>
+  <div class="grant-detail">
+    M Watanabe, H Li, Y Kashiwa, B Reid, H Iida, A E Hassan<br>
+    ACM Transactions on Software Engineering and Methodology, 2026.
+  </div>
+</div>
 
-- IPSJ Kyushu-branch Young Research Seminer 2023 Encouraged Research Award (Recepient: Issei Morita), 2023
-- JSSST Workshop on Foundation of Software Engineering Poster and Demo Award (Recepient: Miki Yonekura), 2023
-- JSSST Workshop on Foundation of Software Engineering Poster and Demo Award (Recepient: Miki Watanabe), 2023
-- IEEE Computer Society Japan Chapter FOSE Young Researcher Award (Recepient: Yuga Matsuda), 2022
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">Understanding Self-Admitted Technical Debt in Test Code</span>
+    <span class="pub-venue">TOSEM [Q1]</span>
+  </div>
+  <div class="grant-detail">
+    I Nakamura, Y Kashiwa, B Lin, H Iida<br>
+    ACM Transactions on Software Engineering and Methodology, 2026.
+  </div>
+</div>
 
-<br>
-<br>
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">Is Self-Admitted Technical Debt Tested?</span>
+    <span class="pub-venue">ESEM [A]</span>
+  </div>
+  <div class="grant-detail">
+    S Yoshimoto, K Horikawa, D Feitosa, Y Kashiwa, H Iida<br>
+    ESEM 2026.
+  </div>
+</div>
 
-## Grants
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">Test Alert Snooze: An Empirical Study of Consecutive Test Failures on CI</span>
+    <span class="pub-venue">ESEM [A]</span>
+  </div>
+  <div class="grant-detail">
+    A Shirakawa, T Shirai, Y Kashiwa, M Kondo, Y Kamei, H Iida<br>
+    ESEM 2026.
+  </div>
+</div>
 
-- 2025-2026: Japan Science and Technology Agency, AIP Acceleration Research, "Explainable Automatic Bug Fixing Based on Software Analysis Technology" (Total: 13,000,000 YEN) [Co-Principal Investigator]
-- 2025-2029: Japan Society for the Promotion of Science, KAKENHI (B), "Proposal for Rational Decision Mining to Support Understanding of Existing Software Code" (Total: 18,850,000 YEN) [Co-Principal Investigator]
-- 2024-2028: Japan Science and Technology Agency, ASPRE, "International Brain Circulation Initiative for Context-Aware AI in Software Development" (Total: 90,000,000 YEN) [Co-Principal Investigator]
-- 2024-2028: Japan Society for the Promotion of Science, KAKENHI (B), "Developing Technique for Bug Localization with Imcomplete Logs" (Total: 18,590,000 YEN) [Principal Investigator]
-- 2022-2026: Japan Science and Technology Agency, PRESTO, "Developing Technique for Anomaly Detection in Software Behaviors" (Total: 52,000,000 YEN) [Principal Investigator]
-- 2021-2024: Japan Society for the Promotion of Science, KAKENHI (Young Researcher), "Developing Technique for Anomaly Detection in Software Behaviors" (Total: 4,550,000 YEN) [Principal Investigator]
-- 2017-2020: Japan Society for the Promotion of Science, KAKENHI (JSPS Fellows), "Development of a detect method for High Impact bug" (Total: 2,800,000 YEN) [Principal Investigator]
-- 2018: Japan Society for the Promotion of Science, Overseas Challenge Program, "Development of a detect method for High Impact bug" (Total: 1,400,000 YEN) [Principal Investigator]
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">An Empirical Study of Policy as Code</span>
+    <span class="pub-venue">MSR [A]</span>
+  </div>
+  <div class="grant-detail">
+    R Opdebeeck, M Alfadel, A Rahman, Y Kashiwa, J F Ferreira, R G Kula, C De Roover<br>
+    MSR 2026.
+  </div>
+</div>
 
-## Projects
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">Does Programming Language Matter? An Empirical Study of Fuzzing Bug Detection</span>
+    <span class="pub-venue">MSR [A]</span>
+  </div>
+  <div class="grant-detail">
+    T Shirai, O Nourry, Y Kashiwa, K Fujiwara, H Iida<br>
+    MSR 2026.
+  </div>
+</div>
 
-- AI-assisted Software Development Acceleration
-  - Just-in-time Bug prediction on CI [@SANER](https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2024_Morita.pdf)
-  - Code Completion: [@SANER](https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2023_Fukumoto.pdf)
-  - Code Review: [@ICSME](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2024_Morikawa.pdf) [@EASE](https://github.com/Yutaro-Kashiwa/papers/blob/master/EASE2024_Watanabe.pdf)
-  - Bug Triage: [@IEICE](https://github.com/Yutaro-Kashiwa/papers/blob/master/IEICE2020_Kashiwa.pdf)
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">My Fuzzers Won't Build: An Empirical Study of Fuzzing Build Failures</span>
+    <span class="pub-venue">TOSEM [Q1]</span>
+  </div>
+  <div class="grant-detail">
+    O Nourry, Y Kashiwa, W Shang, H Shu, Y Kamei<br>
+    ACM Transactions on Software Engineering and Methodology, 2024.
+  </div>
+</div>
 
-- DevOps (Testing)
-  - Build Acceleration: [@ASE](https://github.com/Yutaro-Kashiwa/papers/blob/master/ASE2024_Yin.pdf)
-  - Continuous Fuzzing: [@TOSEM](https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2023_Nourry.pdf) [@TOSEM](https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2024_Nourry.pdf)
-  - Snapshot testing: [@ICSME](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2023_Fujita.pdf)
-  - Test Break: [@ICSME](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2021_Kashiwa.pdf)
-  - Cloud System Testing: [@APSEC](https://github.com/Yutaro-Kashiwa/papers/blob/master/APSEC2023_Suwanachote.pdf)
-  - Docker: [@SCAM](https://github.com/Yutaro-Kashiwa/papers/blob/master/SCAM2024_Mabuchi.pdf) [@SANER](https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2022_Higashi.pdf)
-  - Test Code Refactoring: (To appear)
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">Developer-Applied Accelerations in Continuous Integration</span>
+    <span class="pub-venue">ASE [A*]</span>
+  </div>
+  <div class="grant-detail">
+    M Yin, Y Kashiwa, K Gallaba, M Alfadel, Y Kamei, S McIntosh<br>
+    ASE 2024.
+  </div>
+</div>
 
-- Techinical Debt & Refactoring
-  - Refactoring during Rapid release: [@IST](https://github.com/Yutaro-Kashiwa/papers/blob/master/IST2021_Nourry.pdf)
-  - Refactoring for enargy consumption: [@ICSME](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2022_Nourry.pdf)
-  - SATD introducgtion during Code review: [@IST](https://github.com/Yutaro-Kashiwa/papers/blob/master/IST2022_Kashiwa.pdf)
-  - SATD during Rapid release: (To appear)
-  - Context-aware SATD detection: (To appear)
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">Understanding the Characteristics and the Role of Visual Issue Reports</span>
+    <span class="pub-venue">EMSE [Q1]</span>
+  </div>
+  <div class="grant-detail">
+    H Kuramoto, D Wang, M Kondo, Y Kashiwa, Y Kamei, N Ubayashi<br>
+    Empirical Software Engineering, 2024.
+  </div>
+</div>
 
-- Bug Analysis
-  - Visual Issues: [@EMSE](https://github.com/Yutaro-Kashiwa/papers/blob/master/EMSE2024_Kuramoto.pdf)[@ICPC](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICPC2022_Kuramoto.pdf)
-  - High Impact Bugs: [@ICSME](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2014_Kashiwa.pdf) [@MSR](https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2015_Ohira.pdf)
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">The Human Side of Fuzzing</span>
+    <span class="pub-venue">TOSEM [Q1]</span>
+  </div>
+  <div class="grant-detail">
+    O Nourry, Y Kashiwa, B Lin, G Bavota, M Lanza, Y Kamei<br>
+    ACM Transactions on Software Engineering and Methodology, 2023.
+  </div>
+</div>
 
-- Misc
-  - Issue Linking Algorithm: [@EMSE](https://github.com/Yutaro-Kashiwa/papers/blob/master/EMSE2022%10_Kondo.pdf)
-  - Identifying challenges with Programming video: (To appear)
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">An Empirical Study on Self-admitted Technical Debt in Modern Code Review</span>
+    <span class="pub-venue">IST [Q1]</span>
+  </div>
+  <div class="grant-detail">
+    Y Kashiwa, R Nishikawa, Y Kamei, M Kondo, E Shihab, R Sato, N Ubayashi<br>
+    Information and Software Technology, 2022.
+  </div>
+</div>
 
-## Qualifications
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">An Empirical Study of Issue-Link Algorithms</span>
+    <span class="pub-venue">EMSE [Q1]</span>
+  </div>
+  <div class="grant-detail">
+    M Kondo, Y Kashiwa, Y Kamei, O Mizuno<br>
+    Empirical Software Engineering, 2022.
+  </div>
+</div>
 
-- Database Specialist (Information-technology Promotion Agency, Japan)
-- Applied Information Technology Engineer (Information-technology Promotion Agency, Japan)
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">Does Refactoring Break Tests and to What Extent?</span>
+    <span class="pub-venue">ICSME [A]</span>
+  </div>
+  <div class="grant-detail">
+    Y Kashiwa, K Shimizu, B Lin, G Bavota, M Lanza, Y Kamei, N Ubayashi<br>
+    ICSME 2021.
+  </div>
+</div>
 
-## Contact
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">Does Shortening the Release Cycle Affect Refactoring Activities</span>
+    <span class="pub-venue">IST [Q1]</span>
+  </div>
+  <div class="grant-detail">
+    O Nourry, Y Kashiwa, Y Kamei, N Ubayashi<br>
+    Information and Software Technology, 2021.
+  </div>
+</div>
 
-yutaro.kashiwa［ａｔ］is.naist.jp
+Other publications: <https://github.com/Yutaro-Kashiwa/papers>
+
+</div>
+
+<div class="section-block">
+<h3>Awards</h3>
+
+<div class="award-list">
+  <div class="group-label">Personal Awards</div>
+  <div>2026: <b>Distinguished Mining Challenge Paper Award, MSR 2026</b></div>
+  <div>2025: Research Encouragement Award, Software Engineering Symposium (SES) 2025</div>
+  <div>2023: Research Encouragement Award, IEICE Special Interest Groups on Software Science</div>
+  <div>2022: IEEE CS Kansai Chapter Young Author Award 2022</div>
+  <div>2022: Research Encouragement Award, IEICE Special Interest Groups on Software Science</div>
+  <div>2021: <b>Specially Selected Paper Award, Transactions of IPSJ</b></div>
+  <div>2016: <b>IPSJ Outstanding Paper Award, Transactions of IPSJ</b></div>
+  <div>2016: <b>IPSJ Yamashita SIG Research Award</b></div>
+  <div>2015: Research Encouragement Award, Software Symposium 2015</div>
+  <div>2015: President's Award, Wakayama University</div>
+  <div>2015: Student Research Award, IPSJ SIGSE</div>
+  <div>2015: <b>Specially Selected Paper Award, Transactions of IPSJ</b></div>
+  <div>2014: <b>Best Paper Award, Software Engineering Symposium 2014</b></div>
+  <div>2013: Interactive Award, Software Engineering Symposium 2013</div>
+  <div style="color:#666; font-size:0.9rem;">Plus 4 internal university awards</div>
+  <div class="group-label">Student Awards (as Supervisor)</div>
+  <div>2025: FOSE2025 Best Poster Presentation Award (Recipient: Kosuke Shimizu)</div>
+  <div>2025: SES 2025 Best International Poster Award (Recipient: Kosei Horikawa)</div>
+  <div>2023: IPSJ Kyushu-branch Young Research Seminar 2023 Encouraged Award (Recipient: Issei Morita)</div>
+  <div>2023: FOSE2023 Poster and Demo Award (Recipient: Miki Yonekura)</div>
+  <div>2023: FOSE2023 Poster and Demo Award (Recipient: Miku Watanabe)</div>
+  <div>2022: IEEE CS Japan Chapter FOSE Young Researcher Award (Recipient: Yuga Matsuda)</div>
+</div>
+
+</div>
+
+<div class="section-block">
+<h3>Grants</h3>
+
+<div class="tab-container">
+  <div class="tab-buttons">
+    <button class="tab-btn active" onclick="showTab(event, 'grant-ongoing')">Ongoing</button>
+    <button class="tab-btn" onclick="showTab(event, 'grant-completed')">Completed</button>
+  </div>
+  <div id="grant-ongoing" class="tab-pane active">
+
+<div class="group-label" style="margin-top:0;">Principal Investigator</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2026-2034: JST FOREST</span>
+  </div>
+  <div class="grant-detail">
+    Project: "Quality Assurance Infrastructure for AI-Driven Software Development"<br>
+    Direct Cost: 49,000,000 JPY, Indirect Cost: 14,700,000 JPY
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2026-2028: JSPS KAKENHI Challenging Research (Exploratory)</span>
+  </div>
+  <div class="grant-detail">
+    Project: "Creating Continuous Usability Testing Infrastructure for Immediate Detection of Usability Degradation"<br>
+    Direct Cost: 5,000,000 JPY, Indirect Cost: 1,500,000 JPY
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2024-2028: JSPS KAKENHI (B)</span>
+  </div>
+  <div class="grant-detail">
+    Project: "Developing Technique for Bug Localization with Incomplete System Logs: Challenge for Automatic System Recovery"<br>
+    Direct Cost: 14,300,000 JPY, Indirect Cost: 4,290,000 JPY
+  </div>
+</div>
+
+<div class="group-label">Co-Investigator</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2026-2030: JSPS KAKENHI (A) (PI: Yasutaka Kamei)</span>
+  </div>
+  <div class="grant-detail">
+    Project: "Software Engineering Neurons: Understanding and Applying SE Knowledge in LLM Intermediate Representations"<br>
+    Direct Cost: 32,100,000 JPY, Indirect Cost: 9,630,000 JPY
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2026-2029: JSPS KAKENHI (B) (PI: Akinori Ihara)</span>
+  </div>
+  <div class="grant-detail">
+    Project: "Understanding and Preventing Model Collapse of Generative AI in System Development"<br>
+    Direct Cost: 14,100,000 JPY, Indirect Cost: 4,230,000 JPY
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2026-2028: JST PRESTO Fusion Research (PI: Shinobu Miwa)</span>
+  </div>
+  <div class="grant-detail">
+    Project: "Automatic Generation of Parallel Secure Computation Code Using AI"<br>
+    Direct Cost: 60,000,000 JPY, Indirect Cost: 18,000,000 JPY
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2025-2029: JSPS KAKENHI (B) (PI: Masanari Kondo)</span>
+  </div>
+  <div class="grant-detail">
+    Project: "Proposal for Rational Decision Mining to Support Understanding of Existing Software Code"<br>
+    Direct Cost: 14,500,000 JPY, Indirect Cost: 4,350,000 JPY
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2024-2028: JST ASPIRE (PI: Yasutaka Kamei)</span>
+  </div>
+  <div class="grant-detail">
+    Project: "International Brain Circulation Initiative for Context-Aware AI in Software Development"<br>
+    Direct Cost: 69,230,000 JPY, Indirect Cost: 20,770,000 JPY
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2023-2029: JST CREST (PI: Toshiaki Aoki)</span>
+  </div>
+  <div class="grant-detail">
+    Project: "Formal Methods and Verification Tools for Next-Generation Automotive Platform Systems"
+  </div>
+</div>
+
+</div>
+  <div id="grant-completed" class="tab-pane">
+
+<div class="group-label" style="margin-top:0;">Principal Investigator</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2022-2026: JST PRESTO</span>
+  </div>
+  <div class="grant-detail">
+    Project: "Developing Technique for Automatic Detection of Anomalous Program Behavior: Machine-Enabled Secure Automatic Testing"<br>
+    Direct Cost: 40,000,000 JPY, Indirect Cost: 12,000,000 JPY
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2021-2024: JSPS KAKENHI (Young Researcher)</span>
+  </div>
+  <div class="grant-detail">
+    Project: "Developing Technique for Predicting Test Suites Broken by Refactoring"<br>
+    Direct Cost: 3,500,000 JPY, Indirect Cost: 1,050,000 JPY
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2017-2020: JSPS KAKENHI (JSPS Fellows)</span>
+  </div>
+  <div class="grant-detail">
+    Project: "Development of a Detection Method for High Impact Bugs"<br>
+    Direct Cost: 2,800,000 JPY
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2018-2019: JSPS Overseas Challenge Program</span>
+  </div>
+  <div class="grant-detail">
+    Project: "Development of a Detection Method for High Impact Bugs"<br>
+    Direct Cost: 1,400,000 JPY
+  </div>
+</div>
+
+<div class="group-label">Co-Investigator</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2025-2026: JST AIP Acceleration (PI: Norihiro Yoshida)</span>
+  </div>
+  <div class="grant-detail">
+    Project: "Explainable Automatic Bug Fixing Based on Software Analysis Technology"<br>
+    Direct Cost: 10,000,000 JPY, Indirect Cost: 3,000,000 JPY
+  </div>
+</div>
+
+</div>
+</div>
+
+</div>
+
+<div class="section-block">
+<h3>Research Projects</h3>
+
+<div class="project-area">
+  <div class="project-title">
+    <b>Agentic Software Engineering</b>
+    <span class="project-desc">Empirical analysis and quality improvement of autonomous software development by AI agents</span>
+  </div>
+  <div class="project-papers">
+    <span class="project-topic"><span class="project-topic-name">Context Files</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Worrawalan.pdf">TOSEM</a></span>
+    <span class="project-topic"><span class="project-topic-name">Pull Requests</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Watanabe.pdf">TOSEM</a></span>
+    <span class="project-topic"><span class="project-topic-name">Code Quality</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Horikawa.pdf">MSR</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Watanabe.pdf">MSR</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EASE2026_Sawada.pdf">EASE</a></span>
+    <span class="project-topic"><span class="project-topic-name">Test Generation</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Yoshimoto.pdf">MSR</a></span>
+  </div>
+</div>
+
+<div class="project-area">
+  <div class="project-title">
+    <b>AI-assisted Software Development</b>
+    <span class="project-desc">Development support using ML/LLM (defect prediction, code completion, review automation)</span>
+  </div>
+  <div class="project-papers">
+    <span class="project-topic"><span class="project-topic-name">JIT Defect Prediction</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2024_Morita.pdf">SANER</a></span>
+    <span class="project-topic"><span class="project-topic-name">Code Completion</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2023_Fukumoto.pdf">SANER</a></span>
+    <span class="project-topic"><span class="project-topic-name">Code Review</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2024_Morikawa.pdf">ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EASE2024_Watanabe.pdf">EASE</a></span>
+    <span class="project-topic"><span class="project-topic-name">Bug Triage</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/IEICE2020_Kashiwa.pdf">IEICE</a></span>
+  </div>
+</div>
+
+<div class="project-area">
+  <div class="project-title">
+    <b>DevOps & Testing</b>
+    <span class="project-desc">CI/CD pipeline optimization, fuzzing, and test automation research</span>
+  </div>
+  <div class="project-papers">
+    <span class="project-topic"><span class="project-topic-name">Build Acceleration</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ASE2024_Yin.pdf">ASE</a></span>
+    <span class="project-topic"><span class="project-topic-name">Continuous Fuzzing</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TSE2026_Shirai.pdf">TSE</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2023_Nourry.pdf">TOSEM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2024_Nourry.pdf">TOSEM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Shirai.pdf">MSR</a></span>
+    <span class="project-topic"><span class="project-topic-name">Test Maintenance</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2023_Fujita.pdf">ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2021_Kashiwa.pdf">ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ESEM2026_Shirakawa.pdf">ESEM</a></span>
+    <span class="project-topic"><span class="project-topic-name">Cloud & Container</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/APSEC2023_Suwanachote.pdf">APSEC</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SCAM2024_Mabuchi.pdf">SCAM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2022_Higashi.pdf">SANER</a></span>
+    <span class="project-topic"><span class="project-topic-name">Dependency & Config</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2025_Suwanachote.pdf">MSR</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Opdebeeck.pdf">MSR</a></span>
+  </div>
+</div>
+
+<div class="project-area">
+  <div class="project-title">
+    <b>Technical Debt & Refactoring</b>
+    <span class="project-desc">Detection and management of technical debt, and analysis of refactoring impact on tests</span>
+  </div>
+  <div class="project-papers">
+    <span class="project-topic"><span class="project-topic-name">Refactoring</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/IST2021_Nourry.pdf">IST</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2022_Nourry.pdf">ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SCAM2021_Atwi.pdf">SCAM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2026_Liu.pdf">SANER</a></span>
+    <span class="project-topic"><span class="project-topic-name">SATD</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/IST2022_Kashiwa.pdf">IST</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Nakamura.pdf">TOSEM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ESEM2026_Yoshimoto.pdf">ESEM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICPC2025_Yonekura.pdf">ICPC</a></span>
+  </div>
+</div>
+
+<div class="project-area">
+  <div class="project-title">
+    <b>Bug Analysis</b>
+    <span class="project-desc">Analysis of bug reports, prediction of high-impact bugs, and issue-commit linking</span>
+  </div>
+  <div class="project-papers">
+    <span class="project-topic"><span class="project-topic-name">Visual Issues</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EMSE2024_Kuramoto.pdf">EMSE</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICPC2022_Kuramoto.pdf">ICPC</a></span>
+    <span class="project-topic"><span class="project-topic-name">High Impact Bugs</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2014_Kashiwa.pdf">ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2015_Ohira.pdf">MSR</a></span>
+    <span class="project-topic"><span class="project-topic-name">Issue Linking</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EMSE2022_Kondo.pdf">EMSE</a></span>
+  </div>
+</div>
+
+</div>
+
+<div class="section-block">
+<h3>Qualifications</h3>
+
+<div class="qual-list">
+  <div>Database Specialist (Information-technology Promotion Agency, Japan)</div>
+  <div>Applied Information Technology Engineer (Information-technology Promotion Agency, Japan)</div>
+</div>
+
+</div>
+
+<div class="section-block">
+<h3>Contact</h3>
+
+yutaro.kashiwa [at] is.naist.jp
+
+</div>
+
+<script>
+function showTab(event, tabId) {
+  const container = event.target.closest('.tab-container');
+  container.querySelectorAll('.tab-pane').forEach(p => p.classList.remove('active'));
+  container.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+  container.querySelector('#' + tabId).classList.add('active');
+  event.target.classList.add('active');
+}
+function toggleGrant(header) {
+  header.classList.toggle('active');
+  header.nextElementSibling.classList.toggle('active');
+}
+</script>

--- a/content/ja/authors/yutaro-kashiwa/_index.md
+++ b/content/ja/authors/yutaro-kashiwa/_index.md
@@ -265,6 +265,20 @@ weight: 20
 .grant-detail.active {
   display: block;
 }
+.pub-pdf {
+  display: inline-block;
+  margin-top: 0.3rem;
+  background: #e3f2fd;
+  color: #1565c0;
+  padding: 0.1rem 0.45rem;
+  border-radius: 3px;
+  font-size: 0.8rem;
+  text-decoration: none;
+  transition: background 0.2s;
+}
+.pub-pdf:hover {
+  background: #bbdefb;
+}
 </style>
 
 <div class="section-block">
@@ -310,6 +324,7 @@ weight: 20
   <div class="grant-detail">
     T Shirai, O Nourry, Y Kashiwa, K Fujiwara, Y Kamei, H Iida<br>
     IEEE Transactions on Software Engineering, 2026.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TSE26_Shirai.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -321,6 +336,7 @@ weight: 20
   <div class="grant-detail">
     W Chatlatanagulchai, H Li, Y Kashiwa, B Reid, K Thonglek, P Leelaprute, A Rungsawang, B Manaskasemsak, B Adams, A E Hassan, H Iida<br>
     ACM Transactions on Software Engineering and Methodology, 2026.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Worrawalan.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -332,6 +348,7 @@ weight: 20
   <div class="grant-detail">
     M Watanabe, H Li, Y Kashiwa, B Reid, H Iida, A E Hassan<br>
     ACM Transactions on Software Engineering and Methodology, 2026.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Watanabe.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -343,6 +360,7 @@ weight: 20
   <div class="grant-detail">
     I Nakamura, Y Kashiwa, B Lin, H Iida<br>
     ACM Transactions on Software Engineering and Methodology, 2026.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Nakamura.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -354,6 +372,7 @@ weight: 20
   <div class="grant-detail">
     S Yoshimoto, K Horikawa, D Feitosa, Y Kashiwa, H Iida<br>
     ESEM 2026.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ESEM2026_Yoshimoto.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -365,6 +384,7 @@ weight: 20
   <div class="grant-detail">
     A Shirakawa, T Shirai, Y Kashiwa, M Kondo, Y Kamei, H Iida<br>
     ESEM 2026.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ESEM2026_Shirakawa.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -376,6 +396,7 @@ weight: 20
   <div class="grant-detail">
     R Opdebeeck, M Alfadel, A Rahman, Y Kashiwa, J F Ferreira, R G Kula, C De Roover<br>
     MSR 2026.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Opdebeeck.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -387,6 +408,7 @@ weight: 20
   <div class="grant-detail">
     T Shirai, O Nourry, Y Kashiwa, K Fujiwara, H Iida<br>
     MSR 2026.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Shirai.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -398,6 +420,7 @@ weight: 20
   <div class="grant-detail">
     O Nourry, Y Kashiwa, W Shang, H Shu, Y Kamei<br>
     ACM Transactions on Software Engineering and Methodology, 2024.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2024_Nourry.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -409,6 +432,7 @@ weight: 20
   <div class="grant-detail">
     M Yin, Y Kashiwa, K Gallaba, M Alfadel, Y Kamei, S McIntosh<br>
     ASE 2024.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ASE2024_Yin.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -420,6 +444,7 @@ weight: 20
   <div class="grant-detail">
     H Kuramoto, D Wang, M Kondo, Y Kashiwa, Y Kamei, N Ubayashi<br>
     Empirical Software Engineering, 2024.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EMSE2024_Kuramoto.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -431,6 +456,7 @@ weight: 20
   <div class="grant-detail">
     O Nourry, Y Kashiwa, B Lin, G Bavota, M Lanza, Y Kamei<br>
     ACM Transactions on Software Engineering and Methodology, 2023.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2023_Nourry.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -442,6 +468,7 @@ weight: 20
   <div class="grant-detail">
     Y Kashiwa, R Nishikawa, Y Kamei, M Kondo, E Shihab, R Sato, N Ubayashi<br>
     Information and Software Technology, 2022.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/IST2022_Kashiwa.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -453,6 +480,7 @@ weight: 20
   <div class="grant-detail">
     M Kondo, Y Kashiwa, Y Kamei, O Mizuno<br>
     Empirical Software Engineering, 2022.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EMSE2022_Kondo.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -464,6 +492,7 @@ weight: 20
   <div class="grant-detail">
     Y Kashiwa, K Shimizu, B Lin, G Bavota, M Lanza, Y Kamei, N Ubayashi<br>
     ICSME 2021.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2021_Kashiwa.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -475,6 +504,7 @@ weight: 20
   <div class="grant-detail">
     O Nourry, Y Kashiwa, Y Kamei, N Ubayashi<br>
     Information and Software Technology, 2021.
+    <br><a class="pub-pdf" href="https://github.com/Yutaro-Kashiwa/papers/blob/master/IST2021_Nourry.pdf" target="_blank" rel="noopener">📄 PDF</a>
   </div>
 </div>
 
@@ -569,7 +599,7 @@ weight: 20
 
 <div class="grant-item">
   <div class="grant-header" onclick="toggleGrant(this)">
-    <span class="grant-title">2026-2029：科研費 基盤研究B（代表：伊原彰紀）</span>
+    <span class="grant-title">2026-2029：科研費 基盤研究B（代表：大平雅雄）</span>
   </div>
   <div class="grant-detail">
     研究課題：「システム開発における生成AIのモデル崩壊のメカニズム解明と防止・抑止技術の構築」<br>
@@ -687,10 +717,10 @@ weight: 20
     <span class="project-desc">AIエージェントによる自律的なソフトウェア開発の実態調査と品質向上</span>
   </div>
   <div class="project-papers">
-    <span class="project-topic"><span class="project-topic-name">Context Files</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Worrawalan.pdf">TOSEM</a></span>
-    <span class="project-topic"><span class="project-topic-name">Pull Requests</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Watanabe.pdf">TOSEM</a></span>
-    <span class="project-topic"><span class="project-topic-name">Code Quality</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Horikawa.pdf">MSR</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Watanabe.pdf">MSR</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EASE2026_Sawada.pdf">EASE</a></span>
-    <span class="project-topic"><span class="project-topic-name">Test Generation</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Yoshimoto.pdf">MSR</a></span>
+    <span class="project-topic"><span class="project-topic-name">Context Files</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Worrawalan.pdf" target="_blank" rel="noopener">📄 TOSEM</a></span>
+    <span class="project-topic"><span class="project-topic-name">Pull Requests</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Watanabe.pdf" target="_blank" rel="noopener">📄 TOSEM</a></span>
+    <span class="project-topic"><span class="project-topic-name">Code Quality</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Horikawa.pdf" target="_blank" rel="noopener">📄 MSR</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Watanabe.pdf" target="_blank" rel="noopener">📄 MSR</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EASE2026_Sawada.pdf" target="_blank" rel="noopener">📄 EASE</a></span>
+    <span class="project-topic"><span class="project-topic-name">Test Generation</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Yoshimoto.pdf" target="_blank" rel="noopener">📄 MSR</a></span>
   </div>
 </div>
 
@@ -700,10 +730,10 @@ weight: 20
     <span class="project-desc">機械学習・LLMを活用した開発支援（不具合予測、コード補完、レビュー自動化）</span>
   </div>
   <div class="project-papers">
-    <span class="project-topic"><span class="project-topic-name">JIT Defect Prediction</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2024_Morita.pdf">SANER</a></span>
-    <span class="project-topic"><span class="project-topic-name">Code Completion</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2023_Fukumoto.pdf">SANER</a></span>
-    <span class="project-topic"><span class="project-topic-name">Code Review</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2024_Morikawa.pdf">ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EASE2024_Watanabe.pdf">EASE</a></span>
-    <span class="project-topic"><span class="project-topic-name">Bug Triage</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/IEICE2020_Kashiwa.pdf">IEICE</a></span>
+    <span class="project-topic"><span class="project-topic-name">JIT Defect Prediction</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2024_Morita.pdf" target="_blank" rel="noopener">📄 SANER</a></span>
+    <span class="project-topic"><span class="project-topic-name">Code Completion</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2023_Fukumoto.pdf" target="_blank" rel="noopener">📄 SANER</a></span>
+    <span class="project-topic"><span class="project-topic-name">Code Review</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2024_Morikawa.pdf" target="_blank" rel="noopener">📄 ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EASE2024_Watanabe.pdf" target="_blank" rel="noopener">📄 EASE</a></span>
+    <span class="project-topic"><span class="project-topic-name">Bug Triage</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/IEICE2020_Kashiwa.pdf" target="_blank" rel="noopener">📄 IEICE</a></span>
   </div>
 </div>
 
@@ -713,11 +743,11 @@ weight: 20
     <span class="project-desc">CI/CDパイプラインの最適化、ファジング、テスト自動化の研究</span>
   </div>
   <div class="project-papers">
-    <span class="project-topic"><span class="project-topic-name">Build Acceleration</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ASE2024_Yin.pdf">ASE</a></span>
-    <span class="project-topic"><span class="project-topic-name">Continuous Fuzzing</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TSE2026_Shirai.pdf">TSE</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2023_Nourry.pdf">TOSEM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2024_Nourry.pdf">TOSEM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Shirai.pdf">MSR</a></span>
-    <span class="project-topic"><span class="project-topic-name">Test Maintenance</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2023_Fujita.pdf">ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2021_Kashiwa.pdf">ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ESEM2026_Shirakawa.pdf">ESEM</a></span>
-    <span class="project-topic"><span class="project-topic-name">Cloud & Container</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/APSEC2023_Suwanachote.pdf">APSEC</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SCAM2024_Mabuchi.pdf">SCAM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2022_Higashi.pdf">SANER</a></span>
-    <span class="project-topic"><span class="project-topic-name">Dependency & Config</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2025_Suwanachote.pdf">MSR</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Opdebeeck.pdf">MSR</a></span>
+    <span class="project-topic"><span class="project-topic-name">Build Acceleration</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ASE2024_Yin.pdf" target="_blank" rel="noopener">📄 ASE</a></span>
+    <span class="project-topic"><span class="project-topic-name">Continuous Fuzzing</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TSE26_Shirai.pdf" target="_blank" rel="noopener">📄 TSE</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2023_Nourry.pdf" target="_blank" rel="noopener">📄 TOSEM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2024_Nourry.pdf" target="_blank" rel="noopener">📄 TOSEM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Shirai.pdf" target="_blank" rel="noopener">📄 MSR</a></span>
+    <span class="project-topic"><span class="project-topic-name">Test Maintenance</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2023_Fujita.pdf" target="_blank" rel="noopener">📄 ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2021_Kashiwa.pdf" target="_blank" rel="noopener">📄 ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ESEM2026_Shirakawa.pdf" target="_blank" rel="noopener">📄 ESEM</a></span>
+    <span class="project-topic"><span class="project-topic-name">Cloud & Container</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/APSEC2023_Suwanachote.pdf" target="_blank" rel="noopener">📄 APSEC</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SCAM2024_Mabuchi.pdf" target="_blank" rel="noopener">📄 SCAM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2022_Higashi.pdf" target="_blank" rel="noopener">📄 SANER</a></span>
+    <span class="project-topic"><span class="project-topic-name">Dependency & Config</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2025_Suwanachote.pdf" target="_blank" rel="noopener">📄 MSR</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Opdebeeck.pdf" target="_blank" rel="noopener">📄 MSR</a></span>
   </div>
 </div>
 
@@ -727,8 +757,8 @@ weight: 20
     <span class="project-desc">技術的負債の検出・管理とリファクタリングがテストに与える影響の分析</span>
   </div>
   <div class="project-papers">
-    <span class="project-topic"><span class="project-topic-name">Refactoring</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/IST2021_Nourry.pdf">IST</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2022_Nourry.pdf">ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SCAM2021_Atwi.pdf">SCAM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2026_Liu.pdf">SANER</a></span>
-    <span class="project-topic"><span class="project-topic-name">SATD</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/IST2022_Kashiwa.pdf">IST</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Nakamura.pdf">TOSEM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ESEM2026_Yoshimoto.pdf">ESEM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICPC2025_Yonekura.pdf">ICPC</a></span>
+    <span class="project-topic"><span class="project-topic-name">Refactoring</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/IST2021_Nourry.pdf" target="_blank" rel="noopener">📄 IST</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2022_Nourry.pdf" target="_blank" rel="noopener">📄 ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SCAM2021_Atwi.pdf" target="_blank" rel="noopener">📄 SCAM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2026_Liu.pdf" target="_blank" rel="noopener">📄 SANER</a></span>
+    <span class="project-topic"><span class="project-topic-name">SATD</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/IST2022_Kashiwa.pdf" target="_blank" rel="noopener">📄 IST</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Nakamura.pdf" target="_blank" rel="noopener">📄 TOSEM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ESEM2026_Yoshimoto.pdf" target="_blank" rel="noopener">📄 ESEM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICPC2025_Yonekura.pdf" target="_blank" rel="noopener">📄 ICPC</a></span>
   </div>
 </div>
 
@@ -738,9 +768,9 @@ weight: 20
     <span class="project-desc">不具合報告の分析、重大バグの予測、イシューとコミットの紐付け</span>
   </div>
   <div class="project-papers">
-    <span class="project-topic"><span class="project-topic-name">Visual Issues</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EMSE2024_Kuramoto.pdf">EMSE</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICPC2022_Kuramoto.pdf">ICPC</a></span>
-    <span class="project-topic"><span class="project-topic-name">High Impact Bugs</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2014_Kashiwa.pdf">ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2015_Ohira.pdf">MSR</a></span>
-    <span class="project-topic"><span class="project-topic-name">Issue Linking</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EMSE2022_Kondo.pdf">EMSE</a></span>
+    <span class="project-topic"><span class="project-topic-name">Visual Issues</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EMSE2024_Kuramoto.pdf" target="_blank" rel="noopener">📄 EMSE</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICPC2022_Kuramoto.pdf" target="_blank" rel="noopener">📄 ICPC</a></span>
+    <span class="project-topic"><span class="project-topic-name">High Impact Bugs</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2014_Kashiwa.pdf" target="_blank" rel="noopener">📄 ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2015_Ohira.pdf" target="_blank" rel="noopener">📄 MSR</a></span>
+    <span class="project-topic"><span class="project-topic-name">Issue Linking</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EMSE2022_Kondo.pdf" target="_blank" rel="noopener">📄 EMSE</a></span>
   </div>
 </div>
 

--- a/content/ja/authors/yutaro-kashiwa/_index.md
+++ b/content/ja/authors/yutaro-kashiwa/_index.md
@@ -69,248 +69,542 @@ user_groups:
 weight: 20
 ---
 
+<style>
+/* タブ */
+.tab-container {
+  margin-top: 0.5rem;
+}
+.tab-buttons {
+  display: flex;
+  border-bottom: 2px solid #ddd;
+  margin-bottom: 0.5rem;
+}
+.tab-btn {
+  padding: 0.4rem 1rem;
+  cursor: pointer;
+  border: none;
+  background: none;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #666;
+  border-bottom: 3px solid transparent;
+  margin-bottom: -2px;
+  transition: all 0.2s;
+}
+.tab-btn:hover {
+  color: #1565c0;
+}
+.tab-btn.active {
+  color: #1565c0;
+  border-bottom-color: #1565c0;
+}
+.tab-pane {
+  display: none;
+}
+.tab-pane.active {
+  display: block;
+}
+/* 研究助成アイテム用アコーディオン */
+.grant-item {
+  margin-bottom: 0.5rem;
+}
+.grant-header {
+  display: flex;
+  align-items: flex-start;
+  cursor: pointer;
+  padding: 0.3rem 0;
+}
+.grant-header::before {
+  content: '▶';
+  font-size: 0.7rem;
+  margin-right: 0.5rem;
+  margin-top: 0.25rem;
+  transition: transform 0.2s;
+  color: #666;
+}
+.grant-header.active::before {
+  transform: rotate(90deg);
+}
+.grant-title {
+  font-weight: bold;
+  flex: 1;
+}
+.pub-venue {
+  margin-left: 0.5rem;
+  font-size: 0.85rem;
+  color: #1565c0;
+  font-weight: 500;
+  white-space: nowrap;
+}
+.project-desc {
+  display: block;
+  font-size: 0.9rem;
+  color: #666;
+  margin-top: 0.2rem;
+  margin-bottom: 0.3rem;
+}
+.grant-detail {
+  display: none;
+  padding-left: 1.2rem;
+  margin-top: 0.3rem;
+  color: #555;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+.grant-detail.active {
+  display: block;
+}
+</style>
+
 ## プロフィール
 
 専門はマイニングソフトウェアリポジトリ，特にソフトウェア品質の向上やソフトウェア開発の効率化を目的とし，継続的インテグレーションやDevOpsなどで生じるデータを活用した研究に従事．
 近年は，テスト実行時に動的解析を実施することで得られるトレースログを活用し，Just-In-Time不具合予測や自動リファクタリング等に盛んに取り組んでいる．その他，多数のプロジェクトで国際共同研究に取り組み，カナダ・スイス・オランダ・ルクセンブルグ・タイの大学に所属する多くの研究者と協力して研究を進める．博士（工学）．
-<br>
+
 <br>
 
 ## 略歴
 
 <div>
-<!--    <div>
-        <span class="col-1">2013年&ensp;4月～2015年&ensp;3月:</span>
-        <span class="col-2">和歌山大学大学院システム工学研究科 博士前期課程</span>
-    </div>
--->
-    <div><b>
-        <span class="col-1">2015年&ensp;4月～2017年&ensp;3月: </span>
-        <span class="col-2">株式会社 日立製作所</span>
-    </b></div>
-    <div><b>
- <span class="col-1">2017年&ensp;4月～2020年&ensp;3月:</span>
-        <span class="col-2">和歌山大学大学院システム工学研究科 博士後期課程</span>
-    </b></div>
-    <div><b>
-        <span class="col-1">2017年&ensp;4月～2020年&ensp;3月:</span>
-        <span class="col-2">日本学術振興会 特別研究員（DC1）</span>
-    </b></div>
-    <div>
-        <span class="col-1">　2019年&ensp;4月～2019年&ensp;9月: </span>
-        <span class="col-2">Polytechnique Montréal 客員研究員</span>
-    </div>
-    <div><b>
-        <span class="col-1">2020年&ensp;4月～2022年&ensp;3月: </span>
-        <span class="col-2">九州大学 システム情報科学研究院 特任助教</span>
-    </b></div>
-    <div>
-        <span class="col-1">　2021年11月～2022年&ensp;2月:</span>
-        <span class="col-2">Università della Svizzera italiana 客員研究員</span>
-    </div>
-    <div><b>
-        <span class="col-1">2022年&ensp;4月〜2025年&ensp;3月: &ensp;&ensp;&ensp; &ensp; &ensp;</span>
-        <span class="col-2">奈良先端科学技術大学院大学 先端科学技術研究科 助教</span>
-    </b></div>
-    <div><b>
-        <span class="col-1">2022年10月～2026年&ensp;3月:&ensp;&ensp;&ensp;</span>
-        <span class="col-2">科学技術振興機構 さきがけ研究員(兼任)</span>
-    </b></div>
-    <div>
-        <span class="col-1">　2022年10月～2022年11月:</span>
-        <span class="col-2">Radboud Universtiy 客員研究員　</span>
-    </div>
-    <div>
-        <span class="col-1">　2023年&ensp;9月～2022年10月:</span>
-        <span class="col-2">Radboud Universtiy 客員研究員</span>
-    </div>
-    <div><b>
-        <span class="col-1">2025年&ensp;4月〜現在: &ensp;&ensp;&ensp; &ensp; &ensp;</span>
-        <span class="col-2">奈良先端科学技術大学院大学 先端科学技術研究科 准教授</span>
-    </b></div>
-    <div><b>
-        <span class="col-1">2026年&ensp;8月〜現在: &ensp;&ensp;&ensp; &ensp; &ensp;</span>
-        <span class="col-2">科学技術振興機構 創発研究者(兼任)</span>
-    </b></div>
-
+  <div><b>2015年4月～2017年3月：</b>株式会社 日立製作所</div>
+  <div><b>2017年4月～2020年3月：</b>和歌山大学大学院システム工学研究科 博士後期課程</div>
+  <div><b>2017年4月～2020年3月：</b>日本学術振興会 特別研究員（DC1）</div>
+  <div style="padding-left:1rem;">2019年4月～2019年9月：Polytechnique Montréal 客員研究員</div>
+  <div><b>2020年4月～2022年3月：</b>九州大学 システム情報科学研究院 特任助教</div>
+  <div style="padding-left:1rem;">2021年11月～2022年2月：Università della Svizzera italiana 客員研究員</div>
+  <div><b>2022年4月〜2025年3月：</b>奈良先端科学技術大学院大学 先端科学技術研究科 助教</div>
+  <div><b>2022年10月～2026年3月：</b>科学技術振興機構 さきがけ研究員(兼任)</div>
+  <div style="padding-left:1rem;">2022年10月～2022年11月：Radboud University 客員研究員</div>
+  <div style="padding-left:1rem;">2023年9月～2023年10月：Radboud University 客員研究員</div>
+  <div><b>2025年4月〜現在：</b>奈良先端科学技術大学院大学 先端科学技術研究科 准教授</div>
+  <div><b>2026年8月〜現在：</b>科学技術振興機構 創発研究者(兼任)</div>
 </div>
+
 <br>
 
 ## 主な研究実績
 
-- <b>Large-Scale Empirical Analysis of Continuous Fuzzing: Insights From 1 Million Fuzzing Sessions</b><br>
-  T Shirai, O Nourry, Y Kashiwa, K Fujiwara, Y Kamei, H Iida<br>
-  IEEE Transactions on Software Engineering (TSE), Vol. 52(7), 2026.【CORE A\*論文誌】
-- <b>Agent READMEs: An Empirical Study of Context Files for Agentic Coding</b><br>
-  W Chatlatanagulchai, H Li, Y Kashiwa, B Reid, K Thonglek, P Leelaprute, A Rungsawang, B Manaskasemsak, B Adams, A E Hassan, H Iida<br>
-  ACM Transactions on Software Engineering and Methodology (TOSEM), 2026.【CORE A\*論文誌】
-- <b>On the Use of Agentic Coding: An Empirical Study of Pull Requests on GitHub</b><br>
-  M Watanabe, H Li, Y Kashiwa, B Reid, H Iida, A E Hassan<br>
-  ACM Transactions on Software Engineering and Methodology (TOSEM), 2026.【CORE A\*論文誌】
-- <b>Understanding Self-Admitted Technical Debt in Test Code: An Empirical Study</b><br>
-  I Nakamura, Y Kashiwa, B Lin, H Iida<br>
-  ACM Transactions on Software Engineering and Methodology (TOSEM), 2026.【CORE A\*論文誌】
-- <b>Is Self-Admitted Technical Debt Tested? An Empirical Study of Coverage, Co-change, and Impact</b><br>
-  S Yoshimoto, K Horikawa, D Feitosa, Y Kashiwa, H Iida<br>
-  The 20th International Symposium on Empirical Software Engineering and Measurement (ESEM'26), 2026.【CORE A会議】
-- <b>Test Alert Snooze: An Empirical Study of Consecutive Test Failures on CI</b><br>
-  A Shirakawa, T Shirai, Y Kashiwa, M Kondo, Y Kamei, H Iida<br>
-  The 20th International Symposium on Empirical Software Engineering and Measurement (ESEM'26), 2026.【CORE A会議】
-- <b>An Empirical Study of Policy as Code: Adoption, Purpose, and Maintenance</b><br>
-  R Opdebeeck, M Alfadel, A Rahman, Y Kashiwa, J F Ferreira, R G Kula, C De Roover<br>
-  The 23rd International Conference on Mining Software Repositories (MSR'26), 2026.【CORE A会議】
-- <b>Does Programming Language Matter? An Empirical Study of Fuzzing Bug Detection</b><br>
-  T Shirai, O Nourry, Y Kashiwa, K Fujiwara, H Iida<br>
-  The 23rd International Conference on Mining Software Repositories (MSR'26), 2026.【CORE A会議】
-- <b>My Fuzzers Won't Build: An Empirical Study of Fuzzing Build Failures</b><br>
-  O Nourry, Y Kashiwa, W Shang, H Shu, Y Kamei<br>
-  ACM Transactions on Software Engineering and Methodology (TOSEM), 2024.【CORE A\*論文誌】
-- <b>Developer-Applied Accelerations in Continuous Integration</b><br>
-  M Yin, Y Kashiwa, K Gallaba, M Alfadel, Y Kamei, S McIntosh<br>
-  The 39th IEEE/ACM International Conference on Automated Software Engineering (ASE'24), 2024.【CORE A\*会議】
-- <b>Understanding the Characteristics and the Role of Visual Issue Reports</b><br>
-  H Kuramoto, D Wang, M Kondo, Y Kashiwa, Y Kamei, N Ubayashi<br>
-  Empirical Software Engineering (EMSE), 2024.【CORE A論文誌】
-- <b>The Human Side of Fuzzing: Challenges Faced by Developers During Fuzzing Activities</b><br>
-  O Nourry, Y Kashiwa, B Lin, G Bavota, M Lanza, Y Kamei<br>
-  ACM Transactions on Software Engineering and Methodology (TOSEM), 2023.【CORE A\*論文誌】
-- <b>An Empirical Study on Self-admitted Technical Debt in Modern Code Review</b><br>
-  Y Kashiwa, R Nishikawa, Y Kamei, M Kondo, E Shihab, R Sato, N Ubayashi<br>
-  Information and Software Technology (IST), 2022.【CORE A論文誌】
-- <b>An Empirical Study of Issue-Link Algorithms: Which Issue-Link Algorithms Should We Use?</b><br>
-  M Kondo, Y Kashiwa, Y Kamei, O Mizuno<br>
-  Empirical Software Engineering (EMSE), 2022.【CORE A論文誌】
-- <b>Does Refactoring Break Tests and to What Extent?</b><br>
-  Y Kashiwa, K Shimizu, B Lin, G Bavota, M Lanza, Y Kamei, N Ubayashi<br>
-  37th International Conference on Software Maintenance and Evolution (ICSME'21), 2021.【CORE A会議】
-- <b>Does Shortening the Release Cycle Affect Refactoring Activities: A Case Study of the JDT Core, Platform SWT, and UI projects</b><br>
-  O Nourry, Y Kashiwa, Y Kamei, N Ubayashi<br>
-  Information and Software Technology (IST), 2021.【CORE A論文誌】
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">Large-Scale Empirical Analysis of Continuous Fuzzing</span>
+    <span class="pub-venue">TSE【A*】</span>
+  </div>
+  <div class="grant-detail">
+    T Shirai, O Nourry, Y Kashiwa, K Fujiwara, Y Kamei, H Iida<br>
+    IEEE Transactions on Software Engineering, 2026.
+  </div>
+</div>
 
-その他，以下に論文リストおよびPDFが配備されています．こちらを御覧ください．
-<https://github.com/Yutaro-Kashiwa/papers>
-<br>
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">Agent READMEs: An Empirical Study of Context Files for Agentic Coding</span>
+    <span class="pub-venue">TOSEM【A*】</span>
+  </div>
+  <div class="grant-detail">
+    W Chatlatanagulchai, H Li, Y Kashiwa, B Reid, K Thonglek, P Leelaprute, A Rungsawang, B Manaskasemsak, B Adams, A E Hassan, H Iida<br>
+    ACM Transactions on Software Engineering and Methodology, 2026.
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">On the Use of Agentic Coding: An Empirical Study of Pull Requests on GitHub</span>
+    <span class="pub-venue">TOSEM【A*】</span>
+  </div>
+  <div class="grant-detail">
+    M Watanabe, H Li, Y Kashiwa, B Reid, H Iida, A E Hassan<br>
+    ACM Transactions on Software Engineering and Methodology, 2026.
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">Understanding Self-Admitted Technical Debt in Test Code</span>
+    <span class="pub-venue">TOSEM【A*】</span>
+  </div>
+  <div class="grant-detail">
+    I Nakamura, Y Kashiwa, B Lin, H Iida<br>
+    ACM Transactions on Software Engineering and Methodology, 2026.
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">Is Self-Admitted Technical Debt Tested?</span>
+    <span class="pub-venue">ESEM【A】</span>
+  </div>
+  <div class="grant-detail">
+    S Yoshimoto, K Horikawa, D Feitosa, Y Kashiwa, H Iida<br>
+    ESEM 2026.
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">Test Alert Snooze: An Empirical Study of Consecutive Test Failures on CI</span>
+    <span class="pub-venue">ESEM【A】</span>
+  </div>
+  <div class="grant-detail">
+    A Shirakawa, T Shirai, Y Kashiwa, M Kondo, Y Kamei, H Iida<br>
+    ESEM 2026.
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">An Empirical Study of Policy as Code</span>
+    <span class="pub-venue">MSR【A】</span>
+  </div>
+  <div class="grant-detail">
+    R Opdebeeck, M Alfadel, A Rahman, Y Kashiwa, J F Ferreira, R G Kula, C De Roover<br>
+    MSR 2026.
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">Does Programming Language Matter? An Empirical Study of Fuzzing Bug Detection</span>
+    <span class="pub-venue">MSR【A】</span>
+  </div>
+  <div class="grant-detail">
+    T Shirai, O Nourry, Y Kashiwa, K Fujiwara, H Iida<br>
+    MSR 2026.
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">My Fuzzers Won't Build: An Empirical Study of Fuzzing Build Failures</span>
+    <span class="pub-venue">TOSEM【A*】</span>
+  </div>
+  <div class="grant-detail">
+    O Nourry, Y Kashiwa, W Shang, H Shu, Y Kamei<br>
+    ACM Transactions on Software Engineering and Methodology, 2024.
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">Developer-Applied Accelerations in Continuous Integration</span>
+    <span class="pub-venue">ASE【A*】</span>
+  </div>
+  <div class="grant-detail">
+    M Yin, Y Kashiwa, K Gallaba, M Alfadel, Y Kamei, S McIntosh<br>
+    ASE 2024.
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">Understanding the Characteristics and the Role of Visual Issue Reports</span>
+    <span class="pub-venue">EMSE【A】</span>
+  </div>
+  <div class="grant-detail">
+    H Kuramoto, D Wang, M Kondo, Y Kashiwa, Y Kamei, N Ubayashi<br>
+    Empirical Software Engineering, 2024.
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">The Human Side of Fuzzing</span>
+    <span class="pub-venue">TOSEM【A*】</span>
+  </div>
+  <div class="grant-detail">
+    O Nourry, Y Kashiwa, B Lin, G Bavota, M Lanza, Y Kamei<br>
+    ACM Transactions on Software Engineering and Methodology, 2023.
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">An Empirical Study on Self-admitted Technical Debt in Modern Code Review</span>
+    <span class="pub-venue">IST【A】</span>
+  </div>
+  <div class="grant-detail">
+    Y Kashiwa, R Nishikawa, Y Kamei, M Kondo, E Shihab, R Sato, N Ubayashi<br>
+    Information and Software Technology, 2022.
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">An Empirical Study of Issue-Link Algorithms</span>
+    <span class="pub-venue">EMSE【A】</span>
+  </div>
+  <div class="grant-detail">
+    M Kondo, Y Kashiwa, Y Kamei, O Mizuno<br>
+    Empirical Software Engineering, 2022.
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">Does Refactoring Break Tests and to What Extent?</span>
+    <span class="pub-venue">ICSME【A】</span>
+  </div>
+  <div class="grant-detail">
+    Y Kashiwa, K Shimizu, B Lin, G Bavota, M Lanza, Y Kamei, N Ubayashi<br>
+    ICSME 2021.
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">Does Shortening the Release Cycle Affect Refactoring Activities</span>
+    <span class="pub-venue">IST【A】</span>
+  </div>
+  <div class="grant-detail">
+    O Nourry, Y Kashiwa, Y Kamei, N Ubayashi<br>
+    Information and Software Technology, 2021.
+  </div>
+</div>
+
+その他の論文：<https://github.com/Yutaro-Kashiwa/papers>
+
 <br>
 
 ## 受賞
 
-#### 自身もしくは論文への受賞
+<div class="tab-container">
+  <div class="tab-buttons">
+    <button class="tab-btn active" onclick="showTab(event, 'award-self')">自身の受賞</button>
+    <button class="tab-btn" onclick="showTab(event, 'award-student')">指導学生</button>
+  </div>
+  <div id="award-self" class="tab-pane active">
 
-- 2026年: <b>Distinguished Mining Challenge Paper Award, MSR 2026</b>
+- 2026年: **Distinguished Mining Challenge Paper Award, MSR 2026**
 - 2025年: ソフトウェアエンジニアリングシンポジウム(SES) 2025 研究奨励賞
 - 2023年: 電子情報通信学会ソフトウェアサイエンス研究会研究奨励賞
 - 2022年: IEEE CS Kansai Chapter Young Author Award 2022
 - 2022年: 電子情報通信学会ソフトウェアサイエンス研究会研究奨励賞
-- 2021年: <b>情報処理学会論文誌　特選論文</b>
-- 2016年: <b>情報処理学会論文誌　論文賞</b>
-- 2016年: <b>情報処理学会　山下記念研究賞</b>
+- 2021年: **情報処理学会論文誌　特選論文**
+- 2016年: **情報処理学会論文誌　論文賞**
+- 2016年: **情報処理学会　山下記念研究賞**
 - 2015年: ソフトウェアシンポジウム2015　論文奨励賞
 - 2015年: 和歌山大学　学長表彰
 - 2015年: 情報処理学会ソフトウェア工学研究会　学生研究賞
-- 2015年: <b>情報処理学会論文誌　特選論文</b>
-- 2014年: <b>ソフトウェアエンジニアリングシンポジウム(SES) 2014 最優秀論文賞</b>
+- 2015年: **情報処理学会論文誌　特選論文**
+- 2014年: **ソフトウェアエンジニアリングシンポジウム(SES) 2014 最優秀論文賞**
 - 2013年: ソフトウェアエンジニアリングシンポジウム(SES) 2013 インタラクティブ賞
 
-その他，学内表彰4件（内，3件研究業績表彰，HackU Yahoo 研究所賞等）
+その他，学内表彰4件
 
-#### 指導学生の受賞
+</div>
+  <div id="award-student" class="tab-pane">
 
-- 2025年：ソフトウェア工学の基礎ワークショップ(FOSE2025) ポスター優秀発表賞（受賞者：清水 公亮）
-- 2025年：ソフトウェアエンジニアリングシンポジウム(SES) 2025 Best International Poster Award（受賞者：堀川 康生）
+- 2025年：FOSE2025 ポスター優秀発表賞（受賞者：清水 公亮）
+- 2025年：SES 2025 Best International Poster Award（受賞者：堀川 康生）
 - 2023年：情報処理学会九州支部 若手の会セミナー2023 奨励賞（受賞者：森田 一成）
-- 2023年：ソフトウェア工学の基礎ワークショップ2023 ポスター・デモ賞（受賞者：米倉 未樹）
-- 2023年：ソフトウェア工学の基礎ワークショップ2023 ポスター・デモ賞（受賞者：渡邉 未来）
-- 2022年：IEEE Computer Society Japan Chapter FOSE Young Researcher Award（受賞者：松田 雄河）
+- 2023年：FOSE2023 ポスター・デモ賞（受賞者：米倉 未樹）
+- 2023年：FOSE2023 ポスター・デモ賞（受賞者：渡邉 未来）
+- 2022年：IEEE CS Japan Chapter FOSE Young Researcher Award（受賞者：松田 雄河）
+
+</div>
+</div>
+
 <br>
-  <br>
 
 ## 研究助成
 
-- <b>2026-2034：国立研究開発法人 科学技術振興機構 創発的研究支援事業</b>
-  - 研究代表者
-  - 研究課題：「AI駆動型ソフトウェア開発のための品質保証基盤」
-  - 直接経費：4,900万円，間接経費：1,470万円
-- <b>2026-2028：日本学術振興会 科学研究費助成事業 挑戦的研究（萌芽）</b>
-  - 研究代表者
-  - 研究課題：「ユーザビリティ低下の即時検出を実現する継続的ユーザビリティテスト基盤の創出」
-  - 直接経費：500万円，間接経費：150万円
-- <b>2026-2030：日本学術振興会 科学研究費助成事業 基盤研究A</b>
-  - 研究分担者（研究代表者：亀井 靖高）
-  - 研究課題：「ソフトウェア工学ニューロン：LLM中間表現に潜むソフトウェア工学知識の解明と応用」
-  - 直接経費：3,210万円，間接経費：963万円
-- <b>2026-2029：日本学術振興会 科学研究費助成事業 基盤研究B</b>
-  - 研究分担者
-  - 研究課題：「システム開発における生成AIのモデル崩壊のメカニズム解明と防止・抑止技術の構築」
-  - 直接経費：1,410万円，間接経費：423万円
-- <b>2026-2028：科学技術振興機構（JST）さきがけ融合研究加速課題</b>
-  - 共同研究者（研究代表者：三輪 忍）
-  - 研究課題：「AIの利活用による並列秘密計算コード自動生成」
-  - 直接経費：6,000万円，間接経費：1,800万円
-- <b>2025-2026：科学技術振興機構（JST）AIP加速課題</b>
-  - 主たる共同研究者 (研究代表者：吉田 則裕)
-  - 研究課題：「ソフトウェア解析技術に基づく説明可能自動バグ修正 」
-  - 直接経費：1,000万円，間接経費：300万円
-- <b>2025-2029：日本学術振興会 科学研究費助成事業 基盤研究B</b>
-  - 研究分担者（研究代表者：近藤 将成）
-  - 研究課題：「既存のソフトウェアのコード理解支援のための合理的判断マイニングの提案」
-  - 直接経費：1,450万円，間接経費：435万円
-- <b>2024-2028：科学技術振興機構（JST） ASPIRE 先端国際共同研究推進事業</b>
-  - 主たる共同研究者 (研究代表者：亀井 靖高)
-  - 研究課題：「Context-Awareなソフトウェア開発AIの実現に向けた国際頭脳循環」
-  - 直接経費：6,923万円，間接経費：2,077万円
-- <b>2023-2029：科学技術振興機構（JST）CREST</b>
-  - 共同研究者（研究代表者：青木 利晃）
-  - 研究課題：「次世代車載基盤システムのための形式手法と検証ツールの創出」
-- <b>2024-2028：日本学術振興会 科学研究費助成事業 基盤研究B</b>
-  - 研究代表者
-  - 研究課題：「不完全なシステムログから不具合原因箇所特定技術の構築：システム自動復旧への挑戦」
-  - 直接経費：1,430万円，間接経費：429万円
-- <b>2022-2026：国立研究開発法人 科学技術振興機構 さきがけ</b>
-  - 研究代表者
-  - 研究課題：「プログラム異常動作の自動検出技術の創出：機械が実現するセキュアな自動テスト 」
-  - 直接経費：4,000万円，間接経費：1,200万円
-- <b>2021-2024：日本学術振興会 科学研究費助成事業 若手研究</b>
-  - 研究代表者
-  - 研究課題：「リファクタリングにより破壊されるテストスイート予測技術の開発：自動修正への挑戦 」
-  - 直接経費：350万円，間接経費：105万円
-- <b>2017-2020：日本学術振興会 科学研究費助成事業 特別研究員奨励費</b>
-  - 研究代表者
-  - 研究課題：「重大な影響を及ぼす不具合の検出手法の構築」
-  - 直接経費：280万円
-- <b>2018-2019：日本学術振興会 若手研究者海外挑戦プログラム</b>
-  - 研究代表者
-  - 研究課題：「重大な影響を及ぼす不具合の検出手法の構築」
-  - 直接経費：140万円
+<div class="tab-container">
+  <div class="tab-buttons">
+    <button class="tab-btn active" onclick="showTab(event, 'grant-ongoing')">進行中</button>
+    <button class="tab-btn" onclick="showTab(event, 'grant-completed')">終了</button>
+  </div>
+  <div id="grant-ongoing" class="tab-pane active">
+
+**研究代表者**
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2026-2034：JST 創発的研究支援事業</span>
+  </div>
+  <div class="grant-detail">
+    研究課題：「AI駆動型ソフトウェア開発のための品質保証基盤」<br>
+    直接経費：4,900万円，間接経費：1,470万円
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2026-2028：科研費 挑戦的研究（萌芽）</span>
+  </div>
+  <div class="grant-detail">
+    研究課題：「ユーザビリティ低下の即時検出を実現する継続的ユーザビリティテスト基盤の創出」<br>
+    直接経費：500万円，間接経費：150万円
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2024-2028：科研費 基盤研究B</span>
+  </div>
+  <div class="grant-detail">
+    研究課題：「不完全なシステムログから不具合原因箇所特定技術の構築：システム自動復旧への挑戦」<br>
+    直接経費：1,430万円，間接経費：429万円
+  </div>
+</div>
+
+**研究分担者**
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2026-2030：科研費 基盤研究A（代表：亀井靖高）</span>
+  </div>
+  <div class="grant-detail">
+    研究課題：「ソフトウェア工学ニューロン：LLM中間表現に潜むソフトウェア工学知識の解明と応用」<br>
+    直接経費：3,210万円，間接経費：963万円
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2026-2029：科研費 基盤研究B（代表：伊原彰紀）</span>
+  </div>
+  <div class="grant-detail">
+    研究課題：「システム開発における生成AIのモデル崩壊のメカニズム解明と防止・抑止技術の構築」<br>
+    直接経費：1,410万円，間接経費：423万円
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2026-2028：JST さきがけ融合研究加速課題（代表：三輪忍）</span>
+  </div>
+  <div class="grant-detail">
+    研究課題：「AIの利活用による並列秘密計算コード自動生成」<br>
+    直接経費：6,000万円，間接経費：1,800万円
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2025-2029：科研費 基盤研究B（代表：近藤将成）</span>
+  </div>
+  <div class="grant-detail">
+    研究課題：「既存のソフトウェアのコード理解支援のための合理的判断マイニングの提案」<br>
+    直接経費：1,450万円，間接経費：435万円
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2024-2028：JST ASPIRE（代表：亀井靖高）</span>
+  </div>
+  <div class="grant-detail">
+    研究課題：「Context-Awareなソフトウェア開発AIの実現に向けた国際頭脳循環」<br>
+    直接経費：6,923万円，間接経費：2,077万円
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2023-2029：JST CREST（代表：青木利晃）</span>
+  </div>
+  <div class="grant-detail">
+    研究課題：「次世代車載基盤システムのための形式手法と検証ツールの創出」
+  </div>
+</div>
+
+</div>
+  <div id="grant-completed" class="tab-pane">
+
+**研究代表者**
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2022-2026：JST さきがけ</span>
+  </div>
+  <div class="grant-detail">
+    研究課題：「プログラム異常動作の自動検出技術の創出：機械が実現するセキュアな自動テスト」<br>
+    直接経費：4,000万円，間接経費：1,200万円
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2021-2024：科研費 若手研究</span>
+  </div>
+  <div class="grant-detail">
+    研究課題：「リファクタリングにより破壊されるテストスイート予測技術の開発」<br>
+    直接経費：350万円，間接経費：105万円
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2017-2020：科研費 特別研究員奨励費</span>
+  </div>
+  <div class="grant-detail">
+    研究課題：「重大な影響を及ぼす不具合の検出手法の構築」<br>
+    直接経費：280万円
+  </div>
+</div>
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2018-2019：若手研究者海外挑戦プログラム</span>
+  </div>
+  <div class="grant-detail">
+    研究課題：「重大な影響を及ぼす不具合の検出手法の構築」<br>
+    直接経費：140万円
+  </div>
+</div>
+
+**研究分担者**
+
+<div class="grant-item">
+  <div class="grant-header" onclick="toggleGrant(this)">
+    <span class="grant-title">2025-2026：JST AIP加速課題（代表：吉田則裕）</span>
+  </div>
+  <div class="grant-detail">
+    研究課題：「ソフトウェア解析技術に基づく説明可能自動バグ修正」<br>
+    直接経費：1,000万円，間接経費：300万円
+  </div>
+</div>
+
+</div>
+</div>
+
+<br>
 
 ## 研究プロジェクト
 
-- Agentic Software Engineering
+- **Agentic Software Engineering**<br>
+  <span class="project-desc">AIエージェントによる自律的なソフトウェア開発の実態調査と品質向上</span>
   - Context Files: [@TOSEM](https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Worrawalan.pdf)
   - Pull Requests: [@TOSEM](https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Watanabe.pdf)
   - Code Quality: [@MSR](https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Horikawa.pdf) [@MSR](https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Watanabe.pdf) [@EASE](https://github.com/Yutaro-Kashiwa/papers/blob/master/EASE2026_Sawada.pdf)
   - Test Generation: [@MSR](https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Yoshimoto.pdf)
 
-- AI-assisted Software Development
+- **AI-assisted Software Development**<br>
+  <span class="project-desc">機械学習・LLMを活用した開発支援（不具合予測、コード補完、レビュー自動化）</span>
   - JIT Defect Prediction: [@SANER](https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2024_Morita.pdf)
   - Code Completion: [@SANER](https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2023_Fukumoto.pdf)
   - Code Review: [@ICSME](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2024_Morikawa.pdf) [@EASE](https://github.com/Yutaro-Kashiwa/papers/blob/master/EASE2024_Watanabe.pdf)
   - Bug Triage: [@IEICE](https://github.com/Yutaro-Kashiwa/papers/blob/master/IEICE2020_Kashiwa.pdf)
 
-- DevOps & Testing
+- **DevOps & Testing**<br>
+  <span class="project-desc">CI/CDパイプラインの最適化、ファジング、テスト自動化の研究</span>
   - Build Acceleration: [@ASE](https://github.com/Yutaro-Kashiwa/papers/blob/master/ASE2024_Yin.pdf)
   - Continuous Fuzzing: [@TSE](https://github.com/Yutaro-Kashiwa/papers/blob/master/TSE2026_Shirai.pdf) [@TOSEM](https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2023_Nourry.pdf) [@TOSEM](https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2024_Nourry.pdf) [@MSR](https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Shirai.pdf)
   - Test Maintenance: [@ICSME](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2023_Fujita.pdf) [@ICSME](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2021_Kashiwa.pdf) [@ESEM](https://github.com/Yutaro-Kashiwa/papers/blob/master/ESEM2026_Shirakawa.pdf)
   - Cloud & Container: [@APSEC](https://github.com/Yutaro-Kashiwa/papers/blob/master/APSEC2023_Suwanachote.pdf) [@SCAM](https://github.com/Yutaro-Kashiwa/papers/blob/master/SCAM2024_Mabuchi.pdf) [@SANER](https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2022_Higashi.pdf)
   - Dependency & Configuration: [@MSR](https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2025_Suwanachote.pdf) [@MSR](https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Opdebeeck.pdf)
 
-- Technical Debt & Refactoring
+- **Technical Debt & Refactoring**<br>
+  <span class="project-desc">技術的負債の検出・管理とリファクタリングがテストに与える影響の分析</span>
   - Refactoring: [@IST](https://github.com/Yutaro-Kashiwa/papers/blob/master/IST2021_Nourry.pdf) [@ICSME](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2022_Nourry.pdf) [@SCAM](https://github.com/Yutaro-Kashiwa/papers/blob/master/SCAM2021_Atwi.pdf) [@SANER](https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2026_Liu.pdf)
   - SATD: [@IST](https://github.com/Yutaro-Kashiwa/papers/blob/master/IST2022_Kashiwa.pdf) [@TOSEM](https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Nakamura.pdf) [@ESEM](https://github.com/Yutaro-Kashiwa/papers/blob/master/ESEM2026_Yoshimoto.pdf) [@ICPC](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICPC2025_Yonekura.pdf)
 
-- Bug Analysis
+- **Bug Analysis**<br>
+  <span class="project-desc">不具合報告の分析、重大バグの予測、イシューとコミットの紐付け</span>
   - Visual Issues: [@EMSE](https://github.com/Yutaro-Kashiwa/papers/blob/master/EMSE2024_Kuramoto.pdf) [@ICPC](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICPC2022_Kuramoto.pdf)
   - High Impact Bugs: [@ICSME](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2014_Kashiwa.pdf) [@MSR](https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2015_Ohira.pdf)
   - Issue Linking: [@EMSE](https://github.com/Yutaro-Kashiwa/papers/blob/master/EMSE2022_Kondo.pdf)
+
+<br>
 
 ## 資格
 
@@ -320,3 +614,17 @@ weight: 20
 ## Contact
 
 yutaro.kashiwa［ａｔ］is.naist.jp
+
+<script>
+function showTab(event, tabId) {
+  const container = event.target.closest('.tab-container');
+  container.querySelectorAll('.tab-pane').forEach(p => p.classList.remove('active'));
+  container.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+  container.querySelector('#' + tabId).classList.add('active');
+  event.target.classList.add('active');
+}
+function toggleGrant(header) {
+  header.classList.toggle('active');
+  header.nextElementSibling.classList.toggle('active');
+}
+</script>

--- a/content/ja/authors/yutaro-kashiwa/_index.md
+++ b/content/ja/authors/yutaro-kashiwa/_index.md
@@ -298,10 +298,14 @@ weight: 20
 <div class="section-block">
 <h3>主な研究実績</h3>
 
+<p style="font-size:0.85rem; color:#666; margin-bottom:1rem;">
+国際会議のランクは<a href="https://portal.core.edu.au/conf-ranks/" target="_blank">CORE Rankings</a>、論文誌のランクは<a href="https://www.scimagojr.com/" target="_blank">SCImago Journal Rankings (SJR)</a>に基づく
+</p>
+
 <div class="grant-item">
   <div class="grant-header" onclick="toggleGrant(this)">
     <span class="grant-title">Large-Scale Empirical Analysis of Continuous Fuzzing</span>
-    <span class="pub-venue">TSE【A*】</span>
+    <span class="pub-venue">TSE【Q1】</span>
   </div>
   <div class="grant-detail">
     T Shirai, O Nourry, Y Kashiwa, K Fujiwara, Y Kamei, H Iida<br>
@@ -312,7 +316,7 @@ weight: 20
 <div class="grant-item">
   <div class="grant-header" onclick="toggleGrant(this)">
     <span class="grant-title">Agent READMEs: An Empirical Study of Context Files for Agentic Coding</span>
-    <span class="pub-venue">TOSEM【A*】</span>
+    <span class="pub-venue">TOSEM【Q1】</span>
   </div>
   <div class="grant-detail">
     W Chatlatanagulchai, H Li, Y Kashiwa, B Reid, K Thonglek, P Leelaprute, A Rungsawang, B Manaskasemsak, B Adams, A E Hassan, H Iida<br>
@@ -323,7 +327,7 @@ weight: 20
 <div class="grant-item">
   <div class="grant-header" onclick="toggleGrant(this)">
     <span class="grant-title">On the Use of Agentic Coding: An Empirical Study of Pull Requests on GitHub</span>
-    <span class="pub-venue">TOSEM【A*】</span>
+    <span class="pub-venue">TOSEM【Q1】</span>
   </div>
   <div class="grant-detail">
     M Watanabe, H Li, Y Kashiwa, B Reid, H Iida, A E Hassan<br>
@@ -334,7 +338,7 @@ weight: 20
 <div class="grant-item">
   <div class="grant-header" onclick="toggleGrant(this)">
     <span class="grant-title">Understanding Self-Admitted Technical Debt in Test Code</span>
-    <span class="pub-venue">TOSEM【A*】</span>
+    <span class="pub-venue">TOSEM【Q1】</span>
   </div>
   <div class="grant-detail">
     I Nakamura, Y Kashiwa, B Lin, H Iida<br>
@@ -389,7 +393,7 @@ weight: 20
 <div class="grant-item">
   <div class="grant-header" onclick="toggleGrant(this)">
     <span class="grant-title">My Fuzzers Won't Build: An Empirical Study of Fuzzing Build Failures</span>
-    <span class="pub-venue">TOSEM【A*】</span>
+    <span class="pub-venue">TOSEM【Q1】</span>
   </div>
   <div class="grant-detail">
     O Nourry, Y Kashiwa, W Shang, H Shu, Y Kamei<br>
@@ -411,7 +415,7 @@ weight: 20
 <div class="grant-item">
   <div class="grant-header" onclick="toggleGrant(this)">
     <span class="grant-title">Understanding the Characteristics and the Role of Visual Issue Reports</span>
-    <span class="pub-venue">EMSE【A】</span>
+    <span class="pub-venue">EMSE【Q1】</span>
   </div>
   <div class="grant-detail">
     H Kuramoto, D Wang, M Kondo, Y Kashiwa, Y Kamei, N Ubayashi<br>
@@ -422,7 +426,7 @@ weight: 20
 <div class="grant-item">
   <div class="grant-header" onclick="toggleGrant(this)">
     <span class="grant-title">The Human Side of Fuzzing</span>
-    <span class="pub-venue">TOSEM【A*】</span>
+    <span class="pub-venue">TOSEM【Q1】</span>
   </div>
   <div class="grant-detail">
     O Nourry, Y Kashiwa, B Lin, G Bavota, M Lanza, Y Kamei<br>
@@ -433,7 +437,7 @@ weight: 20
 <div class="grant-item">
   <div class="grant-header" onclick="toggleGrant(this)">
     <span class="grant-title">An Empirical Study on Self-admitted Technical Debt in Modern Code Review</span>
-    <span class="pub-venue">IST【A】</span>
+    <span class="pub-venue">IST【Q1】</span>
   </div>
   <div class="grant-detail">
     Y Kashiwa, R Nishikawa, Y Kamei, M Kondo, E Shihab, R Sato, N Ubayashi<br>
@@ -444,7 +448,7 @@ weight: 20
 <div class="grant-item">
   <div class="grant-header" onclick="toggleGrant(this)">
     <span class="grant-title">An Empirical Study of Issue-Link Algorithms</span>
-    <span class="pub-venue">EMSE【A】</span>
+    <span class="pub-venue">EMSE【Q1】</span>
   </div>
   <div class="grant-detail">
     M Kondo, Y Kashiwa, Y Kamei, O Mizuno<br>

--- a/content/ja/authors/yutaro-kashiwa/_index.md
+++ b/content/ja/authors/yutaro-kashiwa/_index.md
@@ -70,33 +70,51 @@ weight: 20
 ---
 
 <style>
+/* セクションブロック */
+.section-block {
+  background: #f8f9fa;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+.section-block h3 {
+  background: #1565c0;
+  color: #fff;
+  padding: 0.6rem 1rem;
+  margin: -1.5rem -1.5rem 1rem -1.5rem;
+  border-radius: 8px 8px 0 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
 /* タブ */
 .tab-container {
   margin-top: 0.5rem;
 }
 .tab-buttons {
-  display: flex;
-  border-bottom: 2px solid #ddd;
-  margin-bottom: 0.5rem;
+  display: inline-flex;
+  background: #e8e8e8;
+  border-radius: 6px;
+  padding: 3px;
+  margin-bottom: 1rem;
 }
 .tab-btn {
-  padding: 0.4rem 1rem;
+  padding: 0.5rem 1.2rem;
   cursor: pointer;
   border: none;
-  background: none;
-  font-size: 0.95rem;
+  background: transparent;
+  font-size: 0.9rem;
   font-weight: 500;
   color: #666;
-  border-bottom: 3px solid transparent;
-  margin-bottom: -2px;
+  border-radius: 4px;
   transition: all 0.2s;
 }
 .tab-btn:hover {
-  color: #1565c0;
+  color: #333;
 }
 .tab-btn.active {
+  background: #fff;
   color: #1565c0;
-  border-bottom-color: #1565c0;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
 }
 .tab-pane {
   display: none;
@@ -104,85 +122,181 @@ weight: 20
 .tab-pane.active {
   display: block;
 }
-/* 研究助成アイテム用アコーディオン */
+/* アコーディオンアイテム */
 .grant-item {
-  margin-bottom: 0.5rem;
+  margin-bottom: 0;
+  padding: 0.15rem 0;
 }
 .grant-header {
   display: flex;
   align-items: flex-start;
   cursor: pointer;
-  padding: 0.3rem 0;
+  padding: 0.1rem 0;
 }
 .grant-header::before {
   content: '▶';
-  font-size: 0.7rem;
+  font-size: 0.65rem;
   margin-right: 0.5rem;
-  margin-top: 0.25rem;
+  margin-top: 0.3rem;
   transition: transform 0.2s;
-  color: #666;
+  color: #1565c0;
 }
 .grant-header.active::before {
   transform: rotate(90deg);
 }
 .grant-title {
-  font-weight: bold;
+  font-weight: 600;
   flex: 1;
+  color: #333;
 }
 .pub-venue {
   margin-left: 0.5rem;
-  font-size: 0.85rem;
-  color: #1565c0;
+  font-size: 0.8rem;
+  color: #fff;
+  background: #1565c0;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
   font-weight: 500;
   white-space: nowrap;
 }
-.project-desc {
+/* 略歴リスト */
+.career-list > div {
+  padding: 0.15rem 0;
+  line-height: 1.5;
+}
+.sub-item {
+  padding-left: 1.5rem;
+  color: #555;
+  font-size: 0.95rem;
+}
+/* 受賞・資格リスト（箇条書き風） */
+.award-list > div:not(.group-label), .qual-list > div {
+  padding: 0.2rem 0 0.2rem 0;
+  line-height: 1.4;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.award-list > div:not(.group-label)::before {
+  content: '🏆';
+  font-size: 0.75rem;
+  flex-shrink: 0;
+}
+.qual-list > div::before {
+  content: '✓';
+  font-size: 0.85rem;
+  font-weight: bold;
+  color: #1565c0;
+  flex-shrink: 0;
+}
+/* グループ見出し */
+.group-label {
+  font-weight: 600;
+  color: #1565c0;
+  margin-top: 0.8rem;
+  margin-bottom: 0.2rem;
+  padding-bottom: 0.2rem;
+  border-bottom: 1px solid #e0e0e0;
+}
+.group-label:first-child {
+  margin-top: 0;
+}
+/* 研究プロジェクト */
+.project-area {
+  margin-bottom: 0.8rem;
+  padding-left: 1rem;
+  border-left: 3px solid #1565c0;
+}
+.project-title {
+  margin-bottom: 0.2rem;
+}
+.project-title b {
+  font-size: 1rem;
   display: block;
-  font-size: 0.9rem;
+}
+.project-desc {
+  font-size: 0.85rem;
   color: #666;
-  margin-top: 0.2rem;
-  margin-bottom: 0.3rem;
+}
+.project-papers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin-top: 0.3rem;
+}
+.project-topic {
+  display: inline-flex;
+  align-items: center;
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  padding: 0.2rem 0.5rem;
+  font-size: 0.8rem;
+}
+.project-topic-name {
+  color: #333;
+  margin-right: 0.4rem;
+}
+.project-topic a {
+  background: #e3f2fd;
+  color: #1565c0;
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+  font-size: 0.75rem;
+  margin-left: 0.15rem;
+  text-decoration: none;
+  transition: background 0.2s;
+}
+.project-topic a:hover {
+  background: #bbdefb;
 }
 .grant-detail {
   display: none;
   padding-left: 1.2rem;
-  margin-top: 0.3rem;
+  margin-top: 0.2rem;
+  margin-bottom: 0.2rem;
   color: #555;
-  font-size: 0.95rem;
-  line-height: 1.6;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  background: #f8f8f8;
+  padding: 0.4rem 0.8rem;
+  border-radius: 4px;
 }
 .grant-detail.active {
   display: block;
 }
 </style>
 
-## プロフィール
+<div class="section-block">
+<h3>プロフィール</h3>
 
 専門はマイニングソフトウェアリポジトリ，特にソフトウェア品質の向上やソフトウェア開発の効率化を目的とし，継続的インテグレーションやDevOpsなどで生じるデータを活用した研究に従事．
 近年は，テスト実行時に動的解析を実施することで得られるトレースログを活用し，Just-In-Time不具合予測や自動リファクタリング等に盛んに取り組んでいる．その他，多数のプロジェクトで国際共同研究に取り組み，カナダ・スイス・オランダ・ルクセンブルグ・タイの大学に所属する多くの研究者と協力して研究を進める．博士（工学）．
 
-<br>
+</div>
 
-## 略歴
+<div class="section-block">
+<h3>略歴</h3>
 
-<div>
+<div class="career-list">
   <div><b>2015年4月～2017年3月：</b>株式会社 日立製作所</div>
   <div><b>2017年4月～2020年3月：</b>和歌山大学大学院システム工学研究科 博士後期課程</div>
   <div><b>2017年4月～2020年3月：</b>日本学術振興会 特別研究員（DC1）</div>
-  <div style="padding-left:1rem;">2019年4月～2019年9月：Polytechnique Montréal 客員研究員</div>
+  <div class="sub-item">2019年4月～2019年9月：Polytechnique Montréal 客員研究員</div>
   <div><b>2020年4月～2022年3月：</b>九州大学 システム情報科学研究院 特任助教</div>
-  <div style="padding-left:1rem;">2021年11月～2022年2月：Università della Svizzera italiana 客員研究員</div>
+  <div class="sub-item">2021年11月～2022年2月：Università della Svizzera italiana 客員研究員</div>
   <div><b>2022年4月〜2025年3月：</b>奈良先端科学技術大学院大学 先端科学技術研究科 助教</div>
   <div><b>2022年10月～2026年3月：</b>科学技術振興機構 さきがけ研究員(兼任)</div>
-  <div style="padding-left:1rem;">2022年10月～2022年11月：Radboud University 客員研究員</div>
-  <div style="padding-left:1rem;">2023年9月～2023年10月：Radboud University 客員研究員</div>
+  <div class="sub-item">2022年10月～2022年11月：Radboud University 客員研究員</div>
+  <div class="sub-item">2023年9月～2023年10月：Radboud University 客員研究員</div>
   <div><b>2025年4月〜現在：</b>奈良先端科学技術大学院大学 先端科学技術研究科 准教授</div>
   <div><b>2026年8月〜現在：</b>科学技術振興機構 創発研究者(兼任)</div>
 </div>
 
-<br>
+</div>
 
-## 主な研究実績
+<div class="section-block">
+<h3>主な研究実績</h3>
 
 <div class="grant-item">
   <div class="grant-header" onclick="toggleGrant(this)">
@@ -362,50 +476,41 @@ weight: 20
 
 その他の論文：<https://github.com/Yutaro-Kashiwa/papers>
 
-<br>
-
-## 受賞
-
-<div class="tab-container">
-  <div class="tab-buttons">
-    <button class="tab-btn active" onclick="showTab(event, 'award-self')">自身の受賞</button>
-    <button class="tab-btn" onclick="showTab(event, 'award-student')">指導学生</button>
-  </div>
-  <div id="award-self" class="tab-pane active">
-
-- 2026年: **Distinguished Mining Challenge Paper Award, MSR 2026**
-- 2025年: ソフトウェアエンジニアリングシンポジウム(SES) 2025 研究奨励賞
-- 2023年: 電子情報通信学会ソフトウェアサイエンス研究会研究奨励賞
-- 2022年: IEEE CS Kansai Chapter Young Author Award 2022
-- 2022年: 電子情報通信学会ソフトウェアサイエンス研究会研究奨励賞
-- 2021年: **情報処理学会論文誌　特選論文**
-- 2016年: **情報処理学会論文誌　論文賞**
-- 2016年: **情報処理学会　山下記念研究賞**
-- 2015年: ソフトウェアシンポジウム2015　論文奨励賞
-- 2015年: 和歌山大学　学長表彰
-- 2015年: 情報処理学会ソフトウェア工学研究会　学生研究賞
-- 2015年: **情報処理学会論文誌　特選論文**
-- 2014年: **ソフトウェアエンジニアリングシンポジウム(SES) 2014 最優秀論文賞**
-- 2013年: ソフトウェアエンジニアリングシンポジウム(SES) 2013 インタラクティブ賞
-
-その他，学内表彰4件
-
-</div>
-  <div id="award-student" class="tab-pane">
-
-- 2025年：FOSE2025 ポスター優秀発表賞（受賞者：清水 公亮）
-- 2025年：SES 2025 Best International Poster Award（受賞者：堀川 康生）
-- 2023年：情報処理学会九州支部 若手の会セミナー2023 奨励賞（受賞者：森田 一成）
-- 2023年：FOSE2023 ポスター・デモ賞（受賞者：米倉 未樹）
-- 2023年：FOSE2023 ポスター・デモ賞（受賞者：渡邉 未来）
-- 2022年：IEEE CS Japan Chapter FOSE Young Researcher Award（受賞者：松田 雄河）
-
-</div>
 </div>
 
-<br>
+<div class="section-block">
+<h3>受賞</h3>
 
-## 研究助成
+<div class="award-list">
+  <div class="group-label">自身の受賞</div>
+  <div>2026年: <b>Distinguished Mining Challenge Paper Award, MSR 2026</b></div>
+  <div>2025年: ソフトウェアエンジニアリングシンポジウム(SES) 2025 研究奨励賞</div>
+  <div>2023年: 電子情報通信学会ソフトウェアサイエンス研究会研究奨励賞</div>
+  <div>2022年: IEEE CS Kansai Chapter Young Author Award 2022</div>
+  <div>2022年: 電子情報通信学会ソフトウェアサイエンス研究会研究奨励賞</div>
+  <div>2021年: <b>情報処理学会論文誌　特選論文</b></div>
+  <div>2016年: <b>情報処理学会論文誌　論文賞</b></div>
+  <div>2016年: <b>情報処理学会　山下記念研究賞</b></div>
+  <div>2015年: ソフトウェアシンポジウム2015　論文奨励賞</div>
+  <div>2015年: 和歌山大学　学長表彰</div>
+  <div>2015年: 情報処理学会ソフトウェア工学研究会　学生研究賞</div>
+  <div>2015年: <b>情報処理学会論文誌　特選論文</b></div>
+  <div>2014年: <b>ソフトウェアエンジニアリングシンポジウム(SES) 2014 最優秀論文賞</b></div>
+  <div>2013年: ソフトウェアエンジニアリングシンポジウム(SES) 2013 インタラクティブ賞</div>
+  <div style="color:#666; font-size:0.9rem;">その他，学内表彰4件</div>
+  <div class="group-label">指導学生の受賞</div>
+  <div>2025年：FOSE2025 ポスター優秀発表賞（受賞者：清水 公亮）</div>
+  <div>2025年：SES 2025 Best International Poster Award（受賞者：堀川 康生）</div>
+  <div>2023年：情報処理学会九州支部 若手の会セミナー2023 奨励賞（受賞者：森田 一成）</div>
+  <div>2023年：FOSE2023 ポスター・デモ賞（受賞者：米倉 未樹）</div>
+  <div>2023年：FOSE2023 ポスター・デモ賞（受賞者：渡邉 未来）</div>
+  <div>2022年：IEEE CS Japan Chapter FOSE Young Researcher Award（受賞者：松田 雄河）</div>
+</div>
+
+</div>
+
+<div class="section-block">
+<h3>研究助成</h3>
 
 <div class="tab-container">
   <div class="tab-buttons">
@@ -414,7 +519,7 @@ weight: 20
   </div>
   <div id="grant-ongoing" class="tab-pane active">
 
-**研究代表者**
+<div class="group-label" style="margin-top:0;">研究代表者</div>
 
 <div class="grant-item">
   <div class="grant-header" onclick="toggleGrant(this)">
@@ -446,7 +551,7 @@ weight: 20
   </div>
 </div>
 
-**研究分担者**
+<div class="group-label">研究分担者</div>
 
 <div class="grant-item">
   <div class="grant-header" onclick="toggleGrant(this)">
@@ -510,7 +615,7 @@ weight: 20
 </div>
   <div id="grant-completed" class="tab-pane">
 
-**研究代表者**
+<div class="group-label" style="margin-top:0;">研究代表者</div>
 
 <div class="grant-item">
   <div class="grant-header" onclick="toggleGrant(this)">
@@ -552,7 +657,7 @@ weight: 20
   </div>
 </div>
 
-**研究分担者**
+<div class="group-label">研究分担者</div>
 
 <div class="grant-item">
   <div class="grant-header" onclick="toggleGrant(this)">
@@ -567,53 +672,92 @@ weight: 20
 </div>
 </div>
 
-<br>
+</div>
 
-## 研究プロジェクト
+<div class="section-block">
+<h3>研究プロジェクト</h3>
 
-- **Agentic Software Engineering**<br>
-  <span class="project-desc">AIエージェントによる自律的なソフトウェア開発の実態調査と品質向上</span>
-  - Context Files: [@TOSEM](https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Worrawalan.pdf)
-  - Pull Requests: [@TOSEM](https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Watanabe.pdf)
-  - Code Quality: [@MSR](https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Horikawa.pdf) [@MSR](https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Watanabe.pdf) [@EASE](https://github.com/Yutaro-Kashiwa/papers/blob/master/EASE2026_Sawada.pdf)
-  - Test Generation: [@MSR](https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Yoshimoto.pdf)
+<div class="project-area">
+  <div class="project-title">
+    <b>Agentic Software Engineering</b>
+    <span class="project-desc">AIエージェントによる自律的なソフトウェア開発の実態調査と品質向上</span>
+  </div>
+  <div class="project-papers">
+    <span class="project-topic"><span class="project-topic-name">Context Files</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Worrawalan.pdf">TOSEM</a></span>
+    <span class="project-topic"><span class="project-topic-name">Pull Requests</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Watanabe.pdf">TOSEM</a></span>
+    <span class="project-topic"><span class="project-topic-name">Code Quality</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Horikawa.pdf">MSR</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Watanabe.pdf">MSR</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EASE2026_Sawada.pdf">EASE</a></span>
+    <span class="project-topic"><span class="project-topic-name">Test Generation</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Yoshimoto.pdf">MSR</a></span>
+  </div>
+</div>
 
-- **AI-assisted Software Development**<br>
-  <span class="project-desc">機械学習・LLMを活用した開発支援（不具合予測、コード補完、レビュー自動化）</span>
-  - JIT Defect Prediction: [@SANER](https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2024_Morita.pdf)
-  - Code Completion: [@SANER](https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2023_Fukumoto.pdf)
-  - Code Review: [@ICSME](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2024_Morikawa.pdf) [@EASE](https://github.com/Yutaro-Kashiwa/papers/blob/master/EASE2024_Watanabe.pdf)
-  - Bug Triage: [@IEICE](https://github.com/Yutaro-Kashiwa/papers/blob/master/IEICE2020_Kashiwa.pdf)
+<div class="project-area">
+  <div class="project-title">
+    <b>AI-assisted Software Development</b>
+    <span class="project-desc">機械学習・LLMを活用した開発支援（不具合予測、コード補完、レビュー自動化）</span>
+  </div>
+  <div class="project-papers">
+    <span class="project-topic"><span class="project-topic-name">JIT Defect Prediction</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2024_Morita.pdf">SANER</a></span>
+    <span class="project-topic"><span class="project-topic-name">Code Completion</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2023_Fukumoto.pdf">SANER</a></span>
+    <span class="project-topic"><span class="project-topic-name">Code Review</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2024_Morikawa.pdf">ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EASE2024_Watanabe.pdf">EASE</a></span>
+    <span class="project-topic"><span class="project-topic-name">Bug Triage</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/IEICE2020_Kashiwa.pdf">IEICE</a></span>
+  </div>
+</div>
 
-- **DevOps & Testing**<br>
-  <span class="project-desc">CI/CDパイプラインの最適化、ファジング、テスト自動化の研究</span>
-  - Build Acceleration: [@ASE](https://github.com/Yutaro-Kashiwa/papers/blob/master/ASE2024_Yin.pdf)
-  - Continuous Fuzzing: [@TSE](https://github.com/Yutaro-Kashiwa/papers/blob/master/TSE2026_Shirai.pdf) [@TOSEM](https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2023_Nourry.pdf) [@TOSEM](https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2024_Nourry.pdf) [@MSR](https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Shirai.pdf)
-  - Test Maintenance: [@ICSME](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2023_Fujita.pdf) [@ICSME](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2021_Kashiwa.pdf) [@ESEM](https://github.com/Yutaro-Kashiwa/papers/blob/master/ESEM2026_Shirakawa.pdf)
-  - Cloud & Container: [@APSEC](https://github.com/Yutaro-Kashiwa/papers/blob/master/APSEC2023_Suwanachote.pdf) [@SCAM](https://github.com/Yutaro-Kashiwa/papers/blob/master/SCAM2024_Mabuchi.pdf) [@SANER](https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2022_Higashi.pdf)
-  - Dependency & Configuration: [@MSR](https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2025_Suwanachote.pdf) [@MSR](https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Opdebeeck.pdf)
+<div class="project-area">
+  <div class="project-title">
+    <b>DevOps & Testing</b>
+    <span class="project-desc">CI/CDパイプラインの最適化、ファジング、テスト自動化の研究</span>
+  </div>
+  <div class="project-papers">
+    <span class="project-topic"><span class="project-topic-name">Build Acceleration</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ASE2024_Yin.pdf">ASE</a></span>
+    <span class="project-topic"><span class="project-topic-name">Continuous Fuzzing</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TSE2026_Shirai.pdf">TSE</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2023_Nourry.pdf">TOSEM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2024_Nourry.pdf">TOSEM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Shirai.pdf">MSR</a></span>
+    <span class="project-topic"><span class="project-topic-name">Test Maintenance</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2023_Fujita.pdf">ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2021_Kashiwa.pdf">ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ESEM2026_Shirakawa.pdf">ESEM</a></span>
+    <span class="project-topic"><span class="project-topic-name">Cloud & Container</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/APSEC2023_Suwanachote.pdf">APSEC</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SCAM2024_Mabuchi.pdf">SCAM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2022_Higashi.pdf">SANER</a></span>
+    <span class="project-topic"><span class="project-topic-name">Dependency & Config</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2025_Suwanachote.pdf">MSR</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Opdebeeck.pdf">MSR</a></span>
+  </div>
+</div>
 
-- **Technical Debt & Refactoring**<br>
-  <span class="project-desc">技術的負債の検出・管理とリファクタリングがテストに与える影響の分析</span>
-  - Refactoring: [@IST](https://github.com/Yutaro-Kashiwa/papers/blob/master/IST2021_Nourry.pdf) [@ICSME](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2022_Nourry.pdf) [@SCAM](https://github.com/Yutaro-Kashiwa/papers/blob/master/SCAM2021_Atwi.pdf) [@SANER](https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2026_Liu.pdf)
-  - SATD: [@IST](https://github.com/Yutaro-Kashiwa/papers/blob/master/IST2022_Kashiwa.pdf) [@TOSEM](https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Nakamura.pdf) [@ESEM](https://github.com/Yutaro-Kashiwa/papers/blob/master/ESEM2026_Yoshimoto.pdf) [@ICPC](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICPC2025_Yonekura.pdf)
+<div class="project-area">
+  <div class="project-title">
+    <b>Technical Debt & Refactoring</b>
+    <span class="project-desc">技術的負債の検出・管理とリファクタリングがテストに与える影響の分析</span>
+  </div>
+  <div class="project-papers">
+    <span class="project-topic"><span class="project-topic-name">Refactoring</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/IST2021_Nourry.pdf">IST</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2022_Nourry.pdf">ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SCAM2021_Atwi.pdf">SCAM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2026_Liu.pdf">SANER</a></span>
+    <span class="project-topic"><span class="project-topic-name">SATD</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/IST2022_Kashiwa.pdf">IST</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Nakamura.pdf">TOSEM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ESEM2026_Yoshimoto.pdf">ESEM</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICPC2025_Yonekura.pdf">ICPC</a></span>
+  </div>
+</div>
 
-- **Bug Analysis**<br>
-  <span class="project-desc">不具合報告の分析、重大バグの予測、イシューとコミットの紐付け</span>
-  - Visual Issues: [@EMSE](https://github.com/Yutaro-Kashiwa/papers/blob/master/EMSE2024_Kuramoto.pdf) [@ICPC](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICPC2022_Kuramoto.pdf)
-  - High Impact Bugs: [@ICSME](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2014_Kashiwa.pdf) [@MSR](https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2015_Ohira.pdf)
-  - Issue Linking: [@EMSE](https://github.com/Yutaro-Kashiwa/papers/blob/master/EMSE2022_Kondo.pdf)
+<div class="project-area">
+  <div class="project-title">
+    <b>Bug Analysis</b>
+    <span class="project-desc">不具合報告の分析、重大バグの予測、イシューとコミットの紐付け</span>
+  </div>
+  <div class="project-papers">
+    <span class="project-topic"><span class="project-topic-name">Visual Issues</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EMSE2024_Kuramoto.pdf">EMSE</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICPC2022_Kuramoto.pdf">ICPC</a></span>
+    <span class="project-topic"><span class="project-topic-name">High Impact Bugs</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2014_Kashiwa.pdf">ICSME</a><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2015_Ohira.pdf">MSR</a></span>
+    <span class="project-topic"><span class="project-topic-name">Issue Linking</span><a href="https://github.com/Yutaro-Kashiwa/papers/blob/master/EMSE2022_Kondo.pdf">EMSE</a></span>
+  </div>
+</div>
 
-<br>
+</div>
 
-## 資格
+<div class="section-block">
+<h3>資格</h3>
 
-- 情報処理推進機構 データベーススペシャリスト
-- 情報処理推進機構 応用情報技術者
+<div class="qual-list">
+  <div>情報処理推進機構 データベーススペシャリスト</div>
+  <div>情報処理推進機構 応用情報技術者</div>
+</div>
 
-## Contact
+</div>
+
+<div class="section-block">
+<h3>Contact</h3>
 
 yutaro.kashiwa［ａｔ］is.naist.jp
+
+</div>
 
 <script>
 function showTab(event, tabId) {

--- a/content/ja/authors/yutaro-kashiwa/_index.md
+++ b/content/ja/authors/yutaro-kashiwa/_index.md
@@ -20,7 +20,7 @@ organizations:
     url: "https://itcw3.naist.jp/"
 
 # Short bio (displayed in user profile at end of posts)
-bio: 2015 年 (株)日立製作所に入社，システムエンジニアとして勤務．2017 年日本学術振興会特別研究員(DC1)．2020 年 和歌山大学大学院システム工学研究科博士後期課程修了． 同年九州大学大学院システム情報科学研究院 特任助教．2022年 奈良先端科学技術大学院大学 助教．2025年 奈良先端科学技術大学院大学 准教授．ソフトウェア工学，特にソフトウェア品質保証の研究に従事. 博士（工学）．
+bio: 2015 年 (株)日立製作所に入社，システムエンジニアとして勤務．2017 年日本学術振興会特別研究員(DC1)．2020 年 和歌山大学大学院システム工学研究科博士後期課程修了． 同年九州大学大学院システム情報科学研究院 特任助教．2022年 奈良先端科学技術大学院大学 助教．2025年 奈良先端科学技術大学院大学 准教授．2026年 JST創発研究者．ソフトウェア工学，特にソフトウェア品質保証の研究に従事. 博士（工学）．
 
 #education:
 #  courses:
@@ -113,7 +113,7 @@ weight: 20
         <span class="col-2">奈良先端科学技術大学院大学 先端科学技術研究科 助教</span>
     </b></div>
     <div><b>
-        <span class="col-1">2022年10月～現在:&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;</span>
+        <span class="col-1">2022年10月～2026年&ensp;3月:&ensp;&ensp;&ensp;</span>
         <span class="col-2">科学技術振興機構 さきがけ研究員(兼任)</span>
     </b></div>
     <div>
@@ -128,16 +128,41 @@ weight: 20
         <span class="col-1">2025年&ensp;4月〜現在: &ensp;&ensp;&ensp; &ensp; &ensp;</span>
         <span class="col-2">奈良先端科学技術大学院大学 先端科学技術研究科 准教授</span>
     </b></div>
+    <div><b>
+        <span class="col-1">2026年&ensp;8月〜現在: &ensp;&ensp;&ensp; &ensp; &ensp;</span>
+        <span class="col-2">科学技術振興機構 創発研究者(兼任)</span>
+    </b></div>
 
 </div>
 <br>
 
 ## 主な研究実績
 
-- <b>Leveraging Context Information for Self-Admitted Technical Debt Detection</b><br>
-  M Yonekura, Y Kashiwa, B Lin, K Fujiwara, H Iida<br>
-  The 33rd IEEE/ACM International Conference on Program Comprehension (ICPC'25), 2025.【CORE A会議】
-- <b>My Fuzzers Won’t Build: An Empirical Study of Fuzzing Build Failures</b><br>
+- <b>Large-Scale Empirical Analysis of Continuous Fuzzing: Insights From 1 Million Fuzzing Sessions</b><br>
+  T Shirai, O Nourry, Y Kashiwa, K Fujiwara, Y Kamei, H Iida<br>
+  IEEE Transactions on Software Engineering (TSE), Vol. 52(7), 2026.【CORE A\*論文誌】
+- <b>Agent READMEs: An Empirical Study of Context Files for Agentic Coding</b><br>
+  W Chatlatanagulchai, H Li, Y Kashiwa, B Reid, K Thonglek, P Leelaprute, A Rungsawang, B Manaskasemsak, B Adams, A E Hassan, H Iida<br>
+  ACM Transactions on Software Engineering and Methodology (TOSEM), 2026.【CORE A\*論文誌】
+- <b>On the Use of Agentic Coding: An Empirical Study of Pull Requests on GitHub</b><br>
+  M Watanabe, H Li, Y Kashiwa, B Reid, H Iida, A E Hassan<br>
+  ACM Transactions on Software Engineering and Methodology (TOSEM), 2026.【CORE A\*論文誌】
+- <b>Understanding Self-Admitted Technical Debt in Test Code: An Empirical Study</b><br>
+  I Nakamura, Y Kashiwa, B Lin, H Iida<br>
+  ACM Transactions on Software Engineering and Methodology (TOSEM), 2026.【CORE A\*論文誌】
+- <b>Is Self-Admitted Technical Debt Tested? An Empirical Study of Coverage, Co-change, and Impact</b><br>
+  S Yoshimoto, K Horikawa, D Feitosa, Y Kashiwa, H Iida<br>
+  The 20th International Symposium on Empirical Software Engineering and Measurement (ESEM'26), 2026.【CORE A会議】
+- <b>Test Alert Snooze: An Empirical Study of Consecutive Test Failures on CI</b><br>
+  A Shirakawa, T Shirai, Y Kashiwa, M Kondo, Y Kamei, H Iida<br>
+  The 20th International Symposium on Empirical Software Engineering and Measurement (ESEM'26), 2026.【CORE A会議】
+- <b>An Empirical Study of Policy as Code: Adoption, Purpose, and Maintenance</b><br>
+  R Opdebeeck, M Alfadel, A Rahman, Y Kashiwa, J F Ferreira, R G Kula, C De Roover<br>
+  The 23rd International Conference on Mining Software Repositories (MSR'26), 2026.【CORE A会議】
+- <b>Does Programming Language Matter? An Empirical Study of Fuzzing Bug Detection</b><br>
+  T Shirai, O Nourry, Y Kashiwa, K Fujiwara, H Iida<br>
+  The 23rd International Conference on Mining Software Repositories (MSR'26), 2026.【CORE A会議】
+- <b>My Fuzzers Won't Build: An Empirical Study of Fuzzing Build Failures</b><br>
   O Nourry, Y Kashiwa, W Shang, H Shu, Y Kamei<br>
   ACM Transactions on Software Engineering and Methodology (TOSEM), 2024.【CORE A\*論文誌】
 - <b>Developer-Applied Accelerations in Continuous Integration</b><br>
@@ -145,34 +170,25 @@ weight: 20
   The 39th IEEE/ACM International Conference on Automated Software Engineering (ASE'24), 2024.【CORE A\*会議】
 - <b>Understanding the Characteristics and the Role of Visual Issue Reports</b><br>
   H Kuramoto, D Wang, M Kondo, Y Kashiwa, Y Kamei, N Ubayashi<br>
-  Empirical Software Engineering, 2024.【CORE A論文誌】
-- <b>TraceJIT: Evaluating the Impact of Behavioral Code Change on Just-In-Time Defect Prediction</b><br>
-  I Morita, Y Kashiwa, M Kondo, J Sohn, S Macintosh, Y Kamei, and N Ubayashi<br>
-  The 31th IEEE International Conference on Software Analysis, Evolution and Reengineering (SANER), 2024.
-  【CORE A 会議】
+  Empirical Software Engineering (EMSE), 2024.【CORE A論文誌】
 - <b>The Human Side of Fuzzing: Challenges Faced by Developers During Fuzzing Activities</b><br>
-  O Nourry, Y Kashiwa, B Lin, G Bavota, M Lanza, and Y Kamei<br>
-  ACM Transactions on Software Engineering and Methodology (TOSEM), 2023.
-  【CORE A\* 論文誌】
+  O Nourry, Y Kashiwa, B Lin, G Bavota, M Lanza, Y Kamei<br>
+  ACM Transactions on Software Engineering and Methodology (TOSEM), 2023.【CORE A\*論文誌】
 - <b>An Empirical Study on Self-admitted Technical Debt in Modern Code Review</b><br>
   Y Kashiwa, R Nishikawa, Y Kamei, M Kondo, E Shihab, R Sato, N Ubayashi<br>
-  Information and Software Technology (IST), 2022.
-  【CORE A論文誌】
+  Information and Software Technology (IST), 2022.【CORE A論文誌】
 - <b>An Empirical Study of Issue-Link Algorithms: Which Issue-Link Algorithms Should We Use?</b><br>
   M Kondo, Y Kashiwa, Y Kamei, O Mizuno<br>
-  Empirical Software Engineering, 2022.
-  【CORE A論文誌】
+  Empirical Software Engineering (EMSE), 2022.【CORE A論文誌】
 - <b>Does Refactoring Break Tests and to What Extent?</b><br>
   Y Kashiwa, K Shimizu, B Lin, G Bavota, M Lanza, Y Kamei, N Ubayashi<br>
-  37th International Conference on Software Maintenance and Evolution (ICSME2021), 2021.
-  【CORE A国際会議】
+  37th International Conference on Software Maintenance and Evolution (ICSME'21), 2021.【CORE A会議】
 - <b>Does Shortening the Release Cycle Affect Refactoring Activities: A Case Study of the JDT Core, Platform SWT, and UI projects</b><br>
   O Nourry, Y Kashiwa, Y Kamei, N Ubayashi<br>
-  Information and Software Technology (IST), 2021.
-  【CORE A論文誌】
+  Information and Software Technology (IST), 2021.【CORE A論文誌】
 
-その他，以下に論文リスト（英文のみ）およびPDFが配備されています．こちらを御覧ください．
-<https://scholar.google.com/citations?user=hFD-GC8AAAAJ&hl=en>
+その他，以下に論文リストおよびPDFが配備されています．こちらを御覧ください．
+<https://github.com/Yutaro-Kashiwa/papers>
 <br>
 <br>
 
@@ -180,43 +196,71 @@ weight: 20
 
 #### 自身もしくは論文への受賞
 
-- 2024年: 電子情報通信学会ソフトウェアサイエンス研究会研究奨励賞<br>
+- 2026年: <b>Distinguished Mining Challenge Paper Award, MSR 2026</b>
+- 2025年: ソフトウェアエンジニアリングシンポジウム(SES) 2025 研究奨励賞
+- 2023年: 電子情報通信学会ソフトウェアサイエンス研究会研究奨励賞
 - 2022年: IEEE CS Kansai Chapter Young Author Award 2022
-- 2022年: 電子情報通信学会ソフトウェアサイエンス研究会研究奨励賞<br>
+- 2022年: 電子情報通信学会ソフトウェアサイエンス研究会研究奨励賞
 - 2021年: <b>情報処理学会論文誌　特選論文</b>
 - 2016年: <b>情報処理学会論文誌　論文賞</b>
 - 2016年: <b>情報処理学会　山下記念研究賞</b>
-- 2015年: ソフトウェアシンポジウム2015　研究奨励賞
+- 2015年: ソフトウェアシンポジウム2015　論文奨励賞
 - 2015年: 和歌山大学　学長表彰
-- 2015年: 情報処理学会ソフトウェア工学研究会　研究奨励賞
+- 2015年: 情報処理学会ソフトウェア工学研究会　学生研究賞
 - 2015年: <b>情報処理学会論文誌　特選論文</b>
-- 2014年: <b>ソフトウェアエンジニアリングシンポジウム(SES) 2014 最優秀賞論文賞</b>
+- 2014年: <b>ソフトウェアエンジニアリングシンポジウム(SES) 2014 最優秀論文賞</b>
 - 2013年: ソフトウェアエンジニアリングシンポジウム(SES) 2013 インタラクティブ賞
-  その他，学内表彰4件（内，3件研究業績表彰，HackU Yahoo 研究所賞等）
+
+その他，学内表彰4件（内，3件研究業績表彰，HackU Yahoo 研究所賞等）
 
 #### 指導学生の受賞
 
-- 2023年：情報処理学会九州支部 若手の会セミナー2023 奨励賞（受賞者：森田一成）
+- 2025年：ソフトウェア工学の基礎ワークショップ(FOSE2025) ポスター優秀発表賞（受賞者：清水 公亮）
+- 2025年：ソフトウェアエンジニアリングシンポジウム(SES) 2025 Best International Poster Award（受賞者：堀川 康生）
+- 2023年：情報処理学会九州支部 若手の会セミナー2023 奨励賞（受賞者：森田 一成）
 - 2023年：ソフトウェア工学の基礎ワークショップ2023 ポスター・デモ賞（受賞者：米倉 未樹）
 - 2023年：ソフトウェア工学の基礎ワークショップ2023 ポスター・デモ賞（受賞者：渡邉 未来）
 - 2022年：IEEE Computer Society Japan Chapter FOSE Young Researcher Award（受賞者：松田 雄河）
-  <br>
+<br>
   <br>
 
 ## 研究助成
 
+- <b>2026-2034：国立研究開発法人 科学技術振興機構 創発的研究支援事業</b>
+  - 研究代表者
+  - 研究課題：「AI駆動型ソフトウェア開発のための品質保証基盤」
+  - 直接経費：4,900万円，間接経費：1,470万円
+- <b>2026-2028：日本学術振興会 科学研究費助成事業 挑戦的研究（萌芽）</b>
+  - 研究代表者
+  - 研究課題：「ユーザビリティ低下の即時検出を実現する継続的ユーザビリティテスト基盤の創出」
+  - 直接経費：500万円，間接経費：150万円
+- <b>2026-2030：日本学術振興会 科学研究費助成事業 基盤研究A</b>
+  - 研究分担者（研究代表者：亀井 靖高）
+  - 研究課題：「ソフトウェア工学ニューロン：LLM中間表現に潜むソフトウェア工学知識の解明と応用」
+  - 直接経費：3,210万円，間接経費：963万円
+- <b>2026-2029：日本学術振興会 科学研究費助成事業 基盤研究B</b>
+  - 研究分担者
+  - 研究課題：「システム開発における生成AIのモデル崩壊のメカニズム解明と防止・抑止技術の構築」
+  - 直接経費：1,410万円，間接経費：423万円
+- <b>2026-2028：科学技術振興機構（JST）さきがけ融合研究加速課題</b>
+  - 共同研究者（研究代表者：三輪 忍）
+  - 研究課題：「AIの利活用による並列秘密計算コード自動生成」
+  - 直接経費：6,000万円，間接経費：1,800万円
 - <b>2025-2026：科学技術振興機構（JST）AIP加速課題</b>
   - 主たる共同研究者 (研究代表者：吉田 則裕)
   - 研究課題：「ソフトウェア解析技術に基づく説明可能自動バグ修正 」
   - 直接経費：1,000万円，間接経費：300万円
 - <b>2025-2029：日本学術振興会 科学研究費助成事業 基盤研究B</b>
   - 研究分担者（研究代表者：近藤 将成）
-  - 研究課題：「既存のソフトウェアのコード理解支援のための合理的判断マイニングの提案 」
+  - 研究課題：「既存のソフトウェアのコード理解支援のための合理的判断マイニングの提案」
   - 直接経費：1,450万円，間接経費：435万円
-- <b>2024-2028：科学技術振興機構（JST） ASPIRE 先端国際共同研究推進事</b>
+- <b>2024-2028：科学技術振興機構（JST） ASPIRE 先端国際共同研究推進事業</b>
   - 主たる共同研究者 (研究代表者：亀井 靖高)
   - 研究課題：「Context-Awareなソフトウェア開発AIの実現に向けた国際頭脳循環」
   - 直接経費：6,923万円，間接経費：2,077万円
+- <b>2023-2029：科学技術振興機構（JST）CREST</b>
+  - 共同研究者（研究代表者：青木 利晃）
+  - 研究課題：「次世代車載基盤システムのための形式手法と検証ツールの創出」
 - <b>2024-2028：日本学術振興会 科学研究費助成事業 基盤研究B</b>
   - 研究代表者
   - 研究課題：「不完全なシステムログから不具合原因箇所特定技術の構築：システム自動復旧への挑戦」
@@ -240,36 +284,33 @@ weight: 20
 
 ## 研究プロジェクト
 
-- AI-assisted Software Development Acceleration
-  - Just-in-time Bug prediction on CI [@SANER](https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2024_Morita.pdf)
+- Agentic Software Engineering
+  - Context Files: [@TOSEM](https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Worrawalan.pdf)
+  - Pull Requests: [@TOSEM](https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Watanabe.pdf)
+  - Code Quality: [@MSR](https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Horikawa.pdf) [@MSR](https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Watanabe.pdf) [@EASE](https://github.com/Yutaro-Kashiwa/papers/blob/master/EASE2026_Sawada.pdf)
+  - Test Generation: [@MSR](https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Yoshimoto.pdf)
+
+- AI-assisted Software Development
+  - JIT Defect Prediction: [@SANER](https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2024_Morita.pdf)
   - Code Completion: [@SANER](https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2023_Fukumoto.pdf)
   - Code Review: [@ICSME](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2024_Morikawa.pdf) [@EASE](https://github.com/Yutaro-Kashiwa/papers/blob/master/EASE2024_Watanabe.pdf)
   - Bug Triage: [@IEICE](https://github.com/Yutaro-Kashiwa/papers/blob/master/IEICE2020_Kashiwa.pdf)
 
-- DevOps (Testing)
+- DevOps & Testing
   - Build Acceleration: [@ASE](https://github.com/Yutaro-Kashiwa/papers/blob/master/ASE2024_Yin.pdf)
-  - Continuous Fuzzing: [@TOSEM](https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2023_Nourry.pdf) [@TOSEM](https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2024_Nourry.pdf)
-  - Snapshot testing: [@ICSME](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2023_Fujita.pdf)
-  - Test Break: [@ICSME](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2021_Kashiwa.pdf)
-  - Cloud System Testing: [@APSEC](https://github.com/Yutaro-Kashiwa/papers/blob/master/APSEC2023_Suwanachote.pdf)
-  - Docker: [@SCAM](https://github.com/Yutaro-Kashiwa/papers/blob/master/SCAM2024_Mabuchi.pdf) [@SANER](https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2022_Higashi.pdf)
-  - Unused dependencies: [@MSR](https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2025_Suwanachote.pdf)
-  - Test Code Refactoring: (To appear)
+  - Continuous Fuzzing: [@TSE](https://github.com/Yutaro-Kashiwa/papers/blob/master/TSE2026_Shirai.pdf) [@TOSEM](https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2023_Nourry.pdf) [@TOSEM](https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2024_Nourry.pdf) [@MSR](https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Shirai.pdf)
+  - Test Maintenance: [@ICSME](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2023_Fujita.pdf) [@ICSME](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2021_Kashiwa.pdf) [@ESEM](https://github.com/Yutaro-Kashiwa/papers/blob/master/ESEM2026_Shirakawa.pdf)
+  - Cloud & Container: [@APSEC](https://github.com/Yutaro-Kashiwa/papers/blob/master/APSEC2023_Suwanachote.pdf) [@SCAM](https://github.com/Yutaro-Kashiwa/papers/blob/master/SCAM2024_Mabuchi.pdf) [@SANER](https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2022_Higashi.pdf)
+  - Dependency & Configuration: [@MSR](https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2025_Suwanachote.pdf) [@MSR](https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2026_Opdebeeck.pdf)
 
-- Techinical Debt & Refactoring
-  - Refactoring during Rapid release: [@IST](https://github.com/Yutaro-Kashiwa/papers/blob/master/IST2021_Nourry.pdf)
-  - Refactoring for enargy consumption: [@ICSME](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2022_Nourry.pdf)
-  - SATD introducgtion during Code review: [@IST](https://github.com/Yutaro-Kashiwa/papers/blob/master/IST2022_Kashiwa.pdf)
-  - Context-aware SATD detection: [@ICPC](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICPC2025_Yonekura.pdf)
-  - SATD during Rapid release: (To appear)
+- Technical Debt & Refactoring
+  - Refactoring: [@IST](https://github.com/Yutaro-Kashiwa/papers/blob/master/IST2021_Nourry.pdf) [@ICSME](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2022_Nourry.pdf) [@SCAM](https://github.com/Yutaro-Kashiwa/papers/blob/master/SCAM2021_Atwi.pdf) [@SANER](https://github.com/Yutaro-Kashiwa/papers/blob/master/SANER2026_Liu.pdf)
+  - SATD: [@IST](https://github.com/Yutaro-Kashiwa/papers/blob/master/IST2022_Kashiwa.pdf) [@TOSEM](https://github.com/Yutaro-Kashiwa/papers/blob/master/TOSEM2026_Nakamura.pdf) [@ESEM](https://github.com/Yutaro-Kashiwa/papers/blob/master/ESEM2026_Yoshimoto.pdf) [@ICPC](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICPC2025_Yonekura.pdf)
 
 - Bug Analysis
-  - Visual Issues: [@EMSE](https://github.com/Yutaro-Kashiwa/papers/blob/master/EMSE2024_Kuramoto.pdf)[@ICPC](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICPC2022_Kuramoto.pdf)
+  - Visual Issues: [@EMSE](https://github.com/Yutaro-Kashiwa/papers/blob/master/EMSE2024_Kuramoto.pdf) [@ICPC](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICPC2022_Kuramoto.pdf)
   - High Impact Bugs: [@ICSME](https://github.com/Yutaro-Kashiwa/papers/blob/master/ICSME2014_Kashiwa.pdf) [@MSR](https://github.com/Yutaro-Kashiwa/papers/blob/master/MSR2015_Ohira.pdf)
-
-- Misc
-  - Issue Linking Algorithm: [@EMSE](https://github.com/Yutaro-Kashiwa/papers/blob/master/EMSE2022%10_Kondo.pdf)
-  - Identifying challenges with Programming video: (To appear)
+  - Issue Linking: [@EMSE](https://github.com/Yutaro-Kashiwa/papers/blob/master/EMSE2022_Kondo.pdf)
 
 ## 資格
 


### PR DESCRIPTION
## Summary
- JST創発研究者の追加（bio、略歴）
- 主な研究実績の更新（TSE, TOSEM, ESEM, MSR 2026の論文追加）
- 研究助成の追加（創発的研究支援事業、科研費、CREST、さきがけ融合研究）
- 研究プロジェクトセクションの整理・更新
- 指導学生の受賞追加（FOSE2025、SES 2025）

## Test plan
- [ ] ローカルでHugoビルドを確認
- [ ] プロフィールページの表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)